### PR TITLE
Add optional max side limits with checkboxes

### DIFF
--- a/service/image_compression.py
+++ b/service/image_compression.py
@@ -30,8 +30,8 @@ class ImageCompressor:
     def __init__(
         self,
         quality: int = 85,
-        max_largest_side: int = 1920,
-        max_smallest_side: int = 1080,
+        max_largest_side: int | None = 1920,
+        max_smallest_side: int | None = 1080,
         preserve_structure: bool = True,
         output_format: str = "JPEG",
     ):
@@ -40,8 +40,8 @@ class ImageCompressor:
 
         Args:
             quality: JPEG/WebP/AVIF quality (1-100)
-            max_largest_side: Maximum size of the largest side in pixels
-            max_smallest_side: Maximum size of the smallest side in pixels
+            max_largest_side: Maximum size of the largest side in pixels. If None, no limit.
+            max_smallest_side: Maximum size of the smallest side in pixels. If None, no limit.
             preserve_structure: Whether to preserve folder structure
             output_format: Output format ('JPEG', 'WebP', 'AVIF')
         """
@@ -77,7 +77,11 @@ class ImageCompressor:
                 smallest_side = min(width, height)
 
                 # Check if image needs resizing
-                needs_resize = largest_side > self.max_largest_side or smallest_side > self.max_smallest_side
+                needs_resize = False
+                if self.max_largest_side is not None and largest_side > self.max_largest_side:
+                    needs_resize = True
+                if self.max_smallest_side is not None and smallest_side > self.max_smallest_side:
+                    needs_resize = True
 
                 # Check if image needs quality compression (for all formats)
                 needs_quality_compression = True  # Always recompress to ensure quality settings
@@ -109,13 +113,13 @@ class ImageCompressor:
                 # Determine if resizing is needed
                 new_width, new_height = width, height
 
-                if largest_side > self.max_largest_side:
+                if self.max_largest_side is not None and largest_side > self.max_largest_side:
                     # Scale down proportionally
                     scale_factor = self.max_largest_side / largest_side
                     new_width = int(width * scale_factor)
                     new_height = int(height * scale_factor)
 
-                if smallest_side > self.max_smallest_side:
+                if self.max_smallest_side is not None and smallest_side > self.max_smallest_side:
                     # Check if we need to scale down further
                     current_smallest = min(new_width, new_height)
                     if current_smallest > self.max_smallest_side:

--- a/service/main.py
+++ b/service/main.py
@@ -265,21 +265,31 @@ class MainWindow(QMainWindow):
         self.basic_layout.addWidget(self.quality_spinbox, 0, 1)
 
         # Max largest side
-        self.basic_layout.addWidget(QLabel("Max Largest Side:"), 1, 0)
+        self.max_largest_checkbox = QCheckBox("Max Largest Side:")
+        self.max_largest_checkbox.setChecked(True)
+        self.max_largest_checkbox.setToolTip("Enable maximum size limit for the largest side")
+        self.basic_layout.addWidget(self.max_largest_checkbox, 1, 0)
         self.max_largest_spinbox = QSpinBox()
         self.max_largest_spinbox.setRange(100, 10000)
         self.max_largest_spinbox.setValue(1920)
         self.max_largest_spinbox.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
         self.max_largest_spinbox.setToolTip("Maximum size of the largest side in pixels")
+        self.max_largest_checkbox.toggled.connect(self.max_largest_spinbox.setEnabled)
+        self.max_largest_spinbox.setEnabled(self.max_largest_checkbox.isChecked())
         self.basic_layout.addWidget(self.max_largest_spinbox, 1, 1)
 
         # Max smallest side
-        self.basic_layout.addWidget(QLabel("Max Smallest Side:"), 2, 0)
+        self.max_smallest_checkbox = QCheckBox("Max Smallest Side:")
+        self.max_smallest_checkbox.setChecked(True)
+        self.max_smallest_checkbox.setToolTip("Enable maximum size limit for the smallest side")
+        self.basic_layout.addWidget(self.max_smallest_checkbox, 2, 0)
         self.max_smallest_spinbox = QSpinBox()
         self.max_smallest_spinbox.setRange(100, 10000)
         self.max_smallest_spinbox.setValue(1080)
         self.max_smallest_spinbox.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
         self.max_smallest_spinbox.setToolTip("Maximum size of the smallest side in pixels")
+        self.max_smallest_checkbox.toggled.connect(self.max_smallest_spinbox.setEnabled)
+        self.max_smallest_spinbox.setEnabled(self.max_smallest_checkbox.isChecked())
         self.basic_layout.addWidget(self.max_smallest_spinbox, 2, 1)
 
         # Output format
@@ -636,8 +646,8 @@ class MainWindow(QMainWindow):
         # Basic parameters
         params = {
             "quality": self.quality_spinbox.value(),
-            "max_largest_side": self.max_largest_spinbox.value(),
-            "max_smallest_side": self.max_smallest_spinbox.value(),
+            "max_largest_side": self.max_largest_spinbox.value() if self.max_largest_checkbox.isChecked() else None,
+            "max_smallest_side": self.max_smallest_spinbox.value() if self.max_smallest_checkbox.isChecked() else None,
             "preserve_structure": self.preserve_structure_checkbox.isChecked(),
             "output_format": self.format_combo.currentText(),
             "input_directory": str(self.input_directory),


### PR DESCRIPTION
## Summary
- add checkboxes to toggle largest and smallest side limits
- treat disabled max side limits as `None` to skip resizing

## Testing
- `pre-commit run --files service/main.py service/image_compression.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07d39188c8332886f04c793d8f7ff