### PR TITLE
Add dynamic image loading with configurable cache limits

### DIFF
--- a/service/image_comparison.py
+++ b/service/image_comparison.py
@@ -400,9 +400,7 @@ class ThumbnailWidget(QWidget):
         self.image_pair = image_pair
         self.setFixedSize(120, 120)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
-
-        # Create thumbnail
-        self.thumbnail = image_pair.create_thumbnail(QSize(100, 100))
+        self.thumbnail_size = QSize(100, 100)
 
         self.setStyleSheet("""
             QWidget {
@@ -420,11 +418,12 @@ class ThumbnailWidget(QWidget):
     def paintEvent(self, event: QPaintEvent | None) -> None:  # noqa: ARG002
         """Draw the thumbnail."""
         painter = QPainter(self)
+        thumb = self.image_pair.create_thumbnail(self.thumbnail_size)
 
         # Draw thumbnail centered
-        x = (self.width() - self.thumbnail.width()) // 2
-        y = (self.height() - self.thumbnail.height()) // 2
-        painter.drawPixmap(x, y, self.thumbnail)
+        x = (self.width() - thumb.width()) // 2
+        y = (self.height() - thumb.height()) // 2
+        painter.drawPixmap(x, y, thumb)
 
         # Draw name at bottom
         painter.setPen(QPen(QColor(255, 255, 255)))
@@ -748,3 +747,20 @@ def show_comparison_window(
     window = ComparisonWindow(image_pairs, settings_file)
     window.show()
     return window
+
+
+def main() -> None:
+    """Run comparison viewer with image pairs from command line."""
+    files = sys.argv[1:]
+    pairs: list[ImagePair] = []
+    for i in range(0, len(files), 2):
+        if i + 1 < len(files):
+            pairs.append(ImagePair(files[i], files[i + 1]))
+    show_comparison_window(pairs)
+    app = QApplication.instance()
+    if app is not None:
+        app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/service/image_pair.py
+++ b/service/image_pair.py
@@ -1,8 +1,19 @@
+import json
 import os
+from collections import OrderedDict
+from pathlib import Path
+from typing import Hashable, TypeVar
 
 from PIL import Image
 from PyQt6.QtCore import QSize, Qt
-from PyQt6.QtGui import QColor, QImage, QPainter, QPen, QPixmap
+from PyQt6.QtGui import (
+    QColor,
+    QImage,
+    QImageReader,
+    QPainter,
+    QPen,
+    QPixmap,
+)
 
 
 def pixmap_from_heic(path: str) -> QPixmap:
@@ -12,68 +23,122 @@ def pixmap_from_heic(path: str) -> QPixmap:
     return QPixmap.fromImage(qimg)
 
 
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+
+class LRUCache[K: Hashable, V](OrderedDict[K, V]):
+    """Simple LRU cache for limiting loaded images."""
+
+    def __init__(self, max_size: int) -> None:
+        super().__init__()
+        self.max_size = max_size
+
+    def get(self, key: K) -> V | None:  # type: ignore[override]
+        if key in self:
+            self.move_to_end(key)
+            return super().__getitem__(key)
+        return None
+
+    def put(self, key: K, value: V) -> None:
+        self[key] = value
+        self.move_to_end(key)
+        if self.max_size > 0 and len(self) > self.max_size:
+            self.popitem(last=False)
+
+
+def _load_limits() -> tuple[int, int]:
+    """Load cache limits from viewer_config.json."""
+    config_path = Path(__file__).with_name("viewer_config.json")
+    if config_path.exists():
+        try:
+            with config_path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return int(data.get("max_images_in_memory", 0)), int(data.get("max_thumbnails_in_memory", 0))
+        except Exception:  # pragma: no cover - fallback to defaults
+            return 0, 0
+    return 0, 0
+
+
+MAX_IMAGES, MAX_THUMBS = _load_limits()
+_image_cache: LRUCache[str, QPixmap] = LRUCache(MAX_IMAGES)
+_thumb_cache: LRUCache[tuple[str, str, int, int], QPixmap] = LRUCache(MAX_THUMBS)
+
+
+def _load_pixmap(path: str) -> QPixmap:
+    """Load full-resolution pixmap with caching."""
+    cached = _image_cache.get(path)
+    if cached is not None:
+        return cached
+    suffix = Path(path).suffix.lower()
+    pixmap = pixmap_from_heic(path) if suffix in {".heic", ".heif"} else QPixmap(path)
+    _image_cache.put(path, pixmap)
+    return pixmap
+
+
+def _load_preview(path: str, size: QSize) -> QPixmap:
+    """Load scaled preview pixmap without keeping full image."""
+    suffix = Path(path).suffix.lower()
+    if suffix in {".heic", ".heif"}:
+        pix = pixmap_from_heic(path)
+        return pix.scaled(size, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+    reader = QImageReader(path)
+    reader.setAutoTransform(True)
+    if size.width() > 0 and size.height() > 0:
+        reader.setScaledSize(size)
+    image = reader.read()
+    pix = QPixmap(path) if image.isNull() else QPixmap.fromImage(image)
+    return pix.scaled(size, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+
+
+def _load_thumbnail(path1: str, path2: str, size: QSize) -> QPixmap:
+    """Create or retrieve a cached thumbnail for an image pair."""
+    key = (path1, path2, size.width(), size.height())
+    cached = _thumb_cache.get(key)
+    if cached is not None:
+        return cached
+
+    combined = QPixmap(size)
+    combined.fill(Qt.GlobalColor.white)
+    painter = QPainter(combined)
+
+    thumb_width = size.width() // 2
+    thumb_height = size.height()
+
+    scaled1 = _load_preview(path1, QSize(thumb_width, thumb_height))
+    x1 = (thumb_width - scaled1.width()) // 2
+    y1 = (thumb_height - scaled1.height()) // 2
+    painter.drawPixmap(x1, y1, scaled1)
+
+    scaled2 = _load_preview(path2, QSize(thumb_width, thumb_height))
+    x2 = thumb_width + (thumb_width - scaled2.width()) // 2
+    y2 = (thumb_height - scaled2.height()) // 2
+    painter.drawPixmap(x2, y2, scaled2)
+
+    pen = QPen(QColor(100, 100, 100), 2)
+    painter.setPen(pen)
+    painter.drawLine(thumb_width, 0, thumb_width, thumb_height)
+
+    painter.end()
+    _thumb_cache.put(key, combined)
+    return combined
+
+
 class ImagePair:
     def __init__(self, image1_path: str, image2_path: str, name: str = "") -> None:
         self.image1_path = image1_path
         self.image2_path = image2_path
         self.name = name or f"{os.path.basename(image1_path)} vs {os.path.basename(image2_path)}"
-        self._pixmap1: QPixmap | None = None
-        self._pixmap2: QPixmap | None = None
 
     def get_pixmap1(self) -> QPixmap:
         """Get the first image pixmap, loading it if necessary."""
-        if self._pixmap1 is None:
-            self._pixmap1 = pixmap_from_heic(self.image1_path)
-        return self._pixmap1
+        return _load_pixmap(self.image1_path)
 
     def get_pixmap2(self) -> QPixmap:
         """Get the second image pixmap, loading it if necessary."""
-        if self._pixmap2 is None:
-            self._pixmap2 = pixmap_from_heic(self.image2_path)
-        return self._pixmap2
+        return _load_pixmap(self.image2_path)
 
     def create_thumbnail(self, size: QSize | None = None) -> QPixmap:
         size = size or QSize(100, 100)
         """Create a thumbnail showing both images side by side."""
-        pixmap1 = self.get_pixmap1()
-        pixmap2 = self.get_pixmap2()
-
-        # Create a combined thumbnail
-        combined = QPixmap(size)
-        combined.fill(Qt.GlobalColor.white)
-
-        painter = QPainter(combined)
-
-        # Calculate thumbnail dimensions
-        thumb_width = size.width() // 2
-        thumb_height = size.height()
-
-        # Draw first image (left side)
-        scaled1 = pixmap1.scaled(
-            thumb_width,
-            thumb_height,
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
-        )
-        x1 = (thumb_width - scaled1.width()) // 2
-        y1 = (thumb_height - scaled1.height()) // 2
-        painter.drawPixmap(x1, y1, scaled1)
-
-        # Draw second image (right side)
-        scaled2 = pixmap2.scaled(
-            thumb_width,
-            thumb_height,
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
-        )
-        x2 = thumb_width + (thumb_width - scaled2.width()) // 2
-        y2 = (thumb_height - scaled2.height()) // 2
-        painter.drawPixmap(x2, y2, scaled2)
-
-        # Draw divider line
-        pen = QPen(QColor(100, 100, 100), 2)
-        painter.setPen(pen)
-        painter.drawLine(thumb_width, 0, thumb_width, thumb_height)
-
-        painter.end()
-        return combined
+        return _load_thumbnail(self.image1_path, self.image2_path, size)

--- a/service/viewer_config.json
+++ b/service/viewer_config.json
@@ -1,0 +1,4 @@
+{
+  "max_images_in_memory": 5,
+  "max_thumbnails_in_memory": 20
+}


### PR DESCRIPTION
## Summary
- Implement LRU caches for full-size images and thumbnails with limits from `viewer_config.json`
- Lazily create thumbnails in the carousel to avoid loading all previews at once
- Allow launching comparison viewer via CLI for image pairs

## Testing
- `uv run pre-commit run --files service/image_pair.py service/image_comparison.py service/viewer_config.json`


------
https://chatgpt.com/codex/tasks/task_e_68b07c5aa7f08332a4a4dae9b0ea9405