### PR TITLE
[photo_compresser] Compare compression parameters in stats dialog

### DIFF
--- a/service/image_comparison_viewer.py
+++ b/service/image_comparison_viewer.py
@@ -601,9 +601,9 @@ class CompressionStatsDialog(QDialog):
             val1_label = QLabel(format_param_value(key, val1))
             val2_label = QLabel(format_param_value(key, val2))
             diff_label = QLabel(diff_param_value(key, val1, val2))
-            if val1 != val2 and (key == "output_format" or fmt1 == fmt2):
+            if val1 == val2 and (key == "output_format" or fmt1 == fmt2):
                 for lbl in (metric_label, val1_label, val2_label, diff_label):
-                    lbl.setStyleSheet("color: #ff5555")
+                    lbl.setStyleSheet("color: #bdbdbd")
             layout.addWidget(metric_label, row, 0)
             layout.addWidget(val1_label, row, 1)
             layout.addWidget(val2_label, row, 2)


### PR DESCRIPTION
## Summary
- show output format, quality, and format-specific options in compression stats
- highlight differing compression settings when both outputs share the same format

## Testing
- `make align_code` *(fails: No rule to make target 'mk/*.mk')*
- `make lint.ruff` *(fails: No rule to make target 'mk/*.mk')*
- `python -m ruff check service/image_comparison_viewer.py`
- `make lint.mypy` *(fails: No rule to make target 'mk/*.mk')*
- `python -m mypy service/image_comparison_viewer.py`
- `make test.pytest` *(fails: No rule to make target 'mk/*.mk')*
- `pytest`
- `pre-commit run --files service/image_comparison_viewer.py`
- `pre-commit-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b090f6bea0833299c7be33a25e9bb6