### PR TITLE
[photo_compresser] Refine comparison preview backgrounds

### DIFF
--- a/service/image_comparison.py
+++ b/service/image_comparison.py
@@ -184,6 +184,10 @@ class ComparisonViewer(QWidget):
 
         # Calculate display positions
         display_rect = self.get_display_rect()
+
+        # Fill unused space with a slightly lighter shade
+        painter.fillRect(display_rect, QColor("#333333"))
+
         center_x = display_rect.center().x() + self.pan_offset.x()
         center_y = display_rect.center().y() + self.pan_offset.y()
 
@@ -421,18 +425,20 @@ class ThumbnailWidget(QWidget):
         """Draw the thumbnail."""
         painter = QPainter(self)
 
-        # Draw thumbnail centered
+        # Draw thumbnail centered with space for the label
+        label_height = 20
+        available_height = self.height() - label_height
         x = (self.width() - self.thumbnail.width()) // 2
-        y = (self.height() - self.thumbnail.height()) // 2
+        y = (available_height - self.thumbnail.height()) // 2
         painter.drawPixmap(x, y, self.thumbnail)
 
-        # Draw name at bottom
+        # Draw name below the thumbnail
         painter.setPen(QPen(QColor(255, 255, 255)))
         font = painter.font()
         font.setPointSize(8)
         painter.setFont(font)
 
-        text_rect = QRect(0, self.height() - 20, self.width(), 20)
+        text_rect = QRect(0, available_height, self.width(), label_height)
         painter.drawText(
             text_rect,
             Qt.AlignmentFlag.AlignCenter,
@@ -459,6 +465,7 @@ class ThumbnailCarousel(QScrollArea):
 
         # Create container widget
         self.container = QWidget()
+        self.container.setStyleSheet("background-color: #1a1a1a;")
         self.container_layout = QHBoxLayout(self.container)
         self.container_layout.setContentsMargins(10, 10, 10, 10)
         self.container_layout.setSpacing(10)
@@ -467,7 +474,7 @@ class ThumbnailCarousel(QScrollArea):
 
         self.setStyleSheet("""
             QScrollArea {
-                background-color: #1e1e1e;
+                background-color: #1a1a1a;
                 border: none;
             }
             QScrollBar:horizontal {

--- a/service/image_comparison_viewer.py
+++ b/service/image_comparison_viewer.py
@@ -207,6 +207,10 @@ class ComparisonViewer(QWidget):
 
         # Calculate display positions
         display_rect = self.get_display_rect()
+
+        # Fill unused space with a slightly lighter shade
+        painter.fillRect(display_rect, QColor("#333333"))
+
         center_x = display_rect.center().x() + self.pan_offset.x()
         center_y = display_rect.center().y() + self.pan_offset.y()
 
@@ -449,18 +453,20 @@ class ThumbnailWidget(QWidget):
         """Draw the thumbnail."""
         painter = QPainter(self)
 
-        # Draw thumbnail centered
+        # Draw thumbnail centered with space for the label
+        label_height = 20
+        available_height = self.height() - label_height
         x = (self.width() - self.thumbnail.width()) // 2
-        y = (self.height() - self.thumbnail.height()) // 2
+        y = (available_height - self.thumbnail.height()) // 2
         painter.drawPixmap(x, y, self.thumbnail)
 
-        # Draw name at bottom
+        # Draw name below the thumbnail
         painter.setPen(QPen(QColor(255, 255, 255)))
         font = painter.font()
         font.setPointSize(8)
         painter.setFont(font)
 
-        text_rect = QRect(0, self.height() - 20, self.width(), 20)
+        text_rect = QRect(0, available_height, self.width(), label_height)
         painter.drawText(
             text_rect,
             Qt.AlignmentFlag.AlignCenter,
@@ -487,6 +493,7 @@ class ThumbnailCarousel(QScrollArea):
 
         # Create container widget
         self.container = QWidget()
+        self.container.setStyleSheet("background-color: #1a1a1a;")
         self.container_layout = QHBoxLayout(self.container)
         self.container_layout.setContentsMargins(10, 10, 10, 10)
         self.container_layout.setSpacing(10)
@@ -495,7 +502,7 @@ class ThumbnailCarousel(QScrollArea):
 
         self.setStyleSheet("""
             QScrollArea {
-                background-color: #1e1e1e;
+                background-color: #1a1a1a;
                 border: none;
             }
             QScrollBar:horizontal {

--- a/service/image_pair.py
+++ b/service/image_pair.py
@@ -38,9 +38,9 @@ class ImagePair:
         pixmap1 = self.get_pixmap1()
         pixmap2 = self.get_pixmap2()
 
-        # Create a combined thumbnail
+        # Create a combined thumbnail with a subtle background
         combined = QPixmap(size)
-        combined.fill(Qt.GlobalColor.white)
+        combined.fill(QColor("#333333"))
 
         painter = QPainter(combined)
 


### PR DESCRIPTION
## Summary
- darken thumbnail carousel to contrast against application background
- place thumbnail names below images to prevent overlap
- fill unused preview space with subtle grey tones

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest` *(fails: unrecognized arguments --cov)*
- `make pre-commit-all`


------
https://chatgpt.com/codex/tasks/task_e_68b0a2f496b4833299acea830153e451