### PR TITLE
[photo_compresser] Unify window styles

### DIFF
--- a/service/constants.py
+++ b/service/constants.py
@@ -15,3 +15,52 @@ SUPPORTED_EXTENSIONS = {
     ".pgm",
     ".pbm",
 }
+
+
+BUTTON_STYLE = """
+    QPushButton {
+        background-color: #0078d4;
+        color: white;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 4px;
+        font-weight: bold;
+    }
+    QPushButton:hover {
+        background-color: #1088e6;
+    }
+    QPushButton:pressed {
+        background-color: #005a9e;
+    }
+    QPushButton:disabled {
+        background-color: #555;
+        color: #aaa;
+    }
+"""
+
+
+WINDOW_STYLE = """
+    QMainWindow {
+        background-color: #f0f0f0;
+    }
+    QGroupBox {
+        font-weight: bold;
+        border: 2px solid #cccccc;
+        border-radius: 5px;
+        margin-top: 1ex;
+        padding-top: 10px;
+    }
+    QGroupBox::title {
+        subcontrol-origin: margin;
+        left: 10px;
+        padding: 0 5px 0 5px;
+    }
+    QLabel[class="tooltip"] {
+        color: #666;
+        font-style: italic;
+        font-size: 11px;
+    }
+"""
+
+
+STATUS_LABEL_STYLE = "color: #666; font-size: 12px; font-style: italic;"

--- a/service/image_comparison_viewer.py
+++ b/service/image_comparison_viewer.py
@@ -34,31 +34,14 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from service.constants import SUPPORTED_EXTENSIONS
+from service.constants import (
+    BUTTON_STYLE,
+    STATUS_LABEL_STYLE,
+    SUPPORTED_EXTENSIONS,
+    WINDOW_STYLE,
+)
 from service.file_utils import format_timedelta
 from service.image_pair import ImagePair
-
-BUTTON_STYLE = """
-    QPushButton {
-        background-color: #0078d4;
-        color: white;
-        border: none;
-        padding: 8px 16px;
-        border-radius: 4px;
-        font-weight: bold;
-    }
-    QPushButton:hover {
-        background-color: #1088e6;
-    }
-    QPushButton:pressed {
-        background-color: #005a9e;
-    }
-    QPushButton:disabled {
-        background-color: #555;
-        color: #aaa;
-    }
-"""
-
 
 FORMATS_PATTERNS = " ".join(f"*.{f}" for f in SUPPORTED_EXTENSIONS)
 FORMATS_PATTERN = f"Images ({FORMATS_PATTERNS})"
@@ -798,11 +781,7 @@ class MainWindow(QMainWindow):
         # Set window properties
         self.setWindowTitle("Image Comparison Viewer")
         self.setGeometry(100, 100, 1200, 800)
-        self.setStyleSheet("""
-            QMainWindow {
-                background-color: #1e1e1e;
-            }
-        """)
+        self.setStyleSheet(WINDOW_STYLE)
 
     def setup_ui(self) -> None:
         """Set up the user interface."""
@@ -843,7 +822,7 @@ class MainWindow(QMainWindow):
 
         # Status label
         self.status_label = QLabel("No images loaded")
-        self.status_label.setStyleSheet("color: #ccc; font-size: 12px;")
+        self.status_label.setStyleSheet(STATUS_LABEL_STYLE)
         controls_layout.addWidget(self.status_label)
 
         main_layout.addLayout(controls_layout)

--- a/service/main.py
+++ b/service/main.py
@@ -33,6 +33,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from service.constants import BUTTON_STYLE, STATUS_LABEL_STYLE, WINDOW_STYLE
 from service.file_utils import format_timedelta
 
 # Import our modules
@@ -171,28 +172,7 @@ class MainWindow(QMainWindow):
         # Set window properties
         self.setWindowTitle("Image Compression Tool")
         self.setGeometry(100, 100, 1000, 800)
-        self.setStyleSheet("""
-            QMainWindow {
-                background-color: #f0f0f0;
-            }
-            QGroupBox {
-                font-weight: bold;
-                border: 2px solid #cccccc;
-                border-radius: 5px;
-                margin-top: 1ex;
-                padding-top: 10px;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px 0 5px;
-            }
-            QLabel[class="tooltip"] {
-                color: #666;
-                font-style: italic;
-                font-size: 11px;
-            }
-        """)
+        self.setStyleSheet(WINDOW_STYLE)
 
     def setup_ui(self) -> None:
         """Set up the user interface."""
@@ -223,22 +203,7 @@ class MainWindow(QMainWindow):
             "padding: 8px; background-color: white; border: 1px solid #ccc; border-radius: 4px;"
         )
         self.select_input_btn = QPushButton("Select Input Directory")
-        self.select_input_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #0078d4;
-                color: white;
-                border: none;
-                padding: 8px 16px;
-                border-radius: 4px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #106ebe;
-            }
-            QPushButton:pressed {
-                background-color: #005a9e;
-            }
-        """)
+        self.select_input_btn.setStyleSheet(BUTTON_STYLE)
 
         input_dir_layout.addWidget(self.input_dir_label, 1)
         input_dir_layout.addWidget(self.select_input_btn)
@@ -252,22 +217,7 @@ class MainWindow(QMainWindow):
             "padding: 8px; background-color: white; border: 1px solid #ccc; border-radius: 4px;"
         )
         self.select_output_btn = QPushButton("Select Output Directory")
-        self.select_output_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #0078d4;
-                color: white;
-                border: none;
-                padding: 8px 16px;
-                border-radius: 4px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #106ebe;
-            }
-            QPushButton:pressed {
-                background-color: #005a9e;
-            }
-        """)
+        self.select_output_btn.setStyleSheet(BUTTON_STYLE)
 
         # Ensure directory selection buttons have the same width
         button_width = max(
@@ -398,7 +348,7 @@ class MainWindow(QMainWindow):
         progress_layout.addWidget(self.progress_bar)
 
         self.status_label = QLabel("Ready to compress images")
-        self.status_label.setStyleSheet("color: #666; font-style: italic;")
+        self.status_label.setStyleSheet(STATUS_LABEL_STYLE)
         progress_layout.addWidget(self.status_label)
 
         main_layout.addWidget(progress_group)
@@ -430,26 +380,7 @@ class MainWindow(QMainWindow):
         self.compress_btn.setEnabled(False)
 
         self.compare_btn = QPushButton("Compare Images")
-        self.compare_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #0078d4;
-                color: white;
-                border: none;
-                padding: 12px 24px;
-                border-radius: 6px;
-                font-weight: bold;
-                font-size: 14px;
-            }
-            QPushButton:hover {
-                background-color: #138496;
-            }
-            QPushButton:pressed {
-                background-color: #117a8b;
-            }
-            QPushButton:disabled {
-                background-color: #6c757d;
-            }
-        """)
+        self.compare_btn.setStyleSheet(BUTTON_STYLE)
 
         button_layout.addWidget(self.compress_btn)
         button_layout.addWidget(self.compare_btn)


### PR DESCRIPTION
## Summary
- centralize shared window, button, and status-label styles in constants
- apply common palette to main window and preview window buttons and status text

## Testing
- `uv run ruff check service/constants.py service/image_comparison_viewer.py service/main.py`
- `uv run mypy service/constants.py service/image_comparison_viewer.py service/main.py`
- `make test.pytest` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb7c8250833288322079e869000f