### PR TITLE
[photo_compresser] Expand profile conditions and add profile manager

### DIFF
--- a/service/collapsible_box.py
+++ b/service/collapsible_box.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QToolButton, QVBoxLayout, QWidget
+
+
+class CollapsibleBox(QWidget):
+    """A simple collapsible panel widget."""
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self.toggle_button = QToolButton()
+        self.toggle_button.setText(title)
+        self.toggle_button.setCheckable(True)
+        self.toggle_button.setChecked(False)
+        self.toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        self.toggle_button.setArrowType(Qt.ArrowType.RightArrow)
+        self.toggle_button.setStyleSheet("QToolButton { border: none; }")
+
+        self.content = QWidget()
+        self.content.setVisible(False)
+        self.content_layout = QVBoxLayout(self.content)
+        self.content_layout.setContentsMargins(0, 0, 0, 0)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.toggle_button)
+        layout.addWidget(self.content)
+
+        self.toggle_button.clicked.connect(self._on_clicked)
+
+    def _on_clicked(self) -> None:
+        expanded = self.toggle_button.isChecked()
+        self.toggle_button.setArrowType(Qt.ArrowType.DownArrow if expanded else Qt.ArrowType.RightArrow)
+        self.content.setVisible(expanded)
+
+    def add_widget(self, widget: QWidget) -> None:
+        self.content_layout.addWidget(widget)

--- a/service/compression_profiles.py
+++ b/service/compression_profiles.py
@@ -149,7 +149,12 @@ def load_profiles(file_path: Path) -> list[CompressionProfile]:
 def select_profile(
     image: Path | str | Image.Image, profiles: Sequence[CompressionProfile]
 ) -> CompressionProfile | None:
-    """Return the first profile whose conditions match the image."""
+    """Return the first profile whose conditions match the image.
+
+    Profiles are evaluated from the end of the sequence to the start so that
+    lower panels in the UI take precedence over the ones above them. The top
+    profile therefore acts as a default fallback.
+    """
     file_size: int | None = None
     if isinstance(image, str | Path):
         path = Path(image)
@@ -164,7 +169,7 @@ def select_profile(
         image_format = (image.format or "").upper()
         has_transparency = "A" in image.getbands() or "transparency" in image.info
         exif = {ExifTags.TAGS.get(k, str(k)): v for k, v in image.getexif().items()}
-    for profile in profiles:
+    for profile in reversed(profiles):
         if profile.conditions.matches(
             width,
             height,

--- a/service/compression_profiles.py
+++ b/service/compression_profiles.py
@@ -1,0 +1,139 @@
+"""Utilities for working with compression profiles."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+from PIL import ExifTags, Image
+
+
+@dataclass(slots=True)
+class ProfileConditions:
+    """Conditions for selecting a compression profile."""
+
+    max_input_smallest_side: int | None = None
+    max_input_largest_side: int | None = None
+    max_input_pixels: int | None = None
+    min_aspect_ratio: float | None = None
+    max_aspect_ratio: float | None = None
+    orientation: str | None = None
+    input_formats: list[str] | None = None
+    requires_transparency: bool | None = None
+    max_input_bytes: int | None = None
+    required_exif: dict[str, Any] | None = None
+
+    def matches(
+        self,
+        width: int,
+        height: int,
+        *,
+        image_format: str | None = None,
+        has_transparency: bool | None = None,
+        file_size: int | None = None,
+        exif: dict[str, Any] | None = None,
+    ) -> bool:
+        """Return ``True`` if the image properties satisfy the conditions."""
+        smallest_side = min(width, height)
+        largest_side = max(width, height)
+        pixels = width * height
+        aspect_ratio = width / height
+        orientation = "square" if width == height else ("landscape" if width > height else "portrait")
+
+        conditions = [
+            self.max_input_smallest_side is None or smallest_side <= self.max_input_smallest_side,
+            self.max_input_largest_side is None or largest_side <= self.max_input_largest_side,
+            self.max_input_pixels is None or pixels <= self.max_input_pixels,
+            self.min_aspect_ratio is None or aspect_ratio >= self.min_aspect_ratio,
+            self.max_aspect_ratio is None or aspect_ratio <= self.max_aspect_ratio,
+            self.orientation is None or orientation == self.orientation,
+            self.input_formats is None
+            or (image_format is not None and image_format.upper() in [f.upper() for f in self.input_formats]),
+            self.requires_transparency is None
+            or (has_transparency is not None and has_transparency == self.requires_transparency),
+            self.max_input_bytes is None or (file_size is not None and file_size <= self.max_input_bytes),
+            not self.required_exif
+            or (exif is not None and all(exif.get(k) == v for k, v in self.required_exif.items())),
+        ]
+        return all(conditions)
+
+
+@dataclass(slots=True)
+class CompressionProfile:
+    """Compression settings with optional selection conditions."""
+
+    name: str
+    quality: int = 75
+    max_largest_side: int | None = None
+    max_smallest_side: int | None = None
+    output_format: str = "JPEG"
+    preserve_structure: bool = True
+    jpeg_params: dict[str, Any] = field(default_factory=dict)
+    webp_params: dict[str, Any] = field(default_factory=dict)
+    avif_params: dict[str, Any] = field(default_factory=dict)
+    conditions: ProfileConditions = field(default_factory=ProfileConditions)
+
+
+def save_profiles(profiles: Sequence[CompressionProfile], file_path: Path) -> Path:
+    """Save compression profiles to ``file_path`` in JSON format."""
+    data = [asdict(profile) for profile in profiles]
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    return file_path
+
+
+def load_profiles(file_path: Path) -> list[CompressionProfile]:
+    """Load compression profiles from ``file_path``."""
+    if not file_path.exists():
+        return []
+    raw = json.loads(file_path.read_text(encoding="utf-8"))
+    profiles: list[CompressionProfile] = []
+    for item in raw:
+        cond = ProfileConditions(**item.get("conditions", {}))
+        profile = CompressionProfile(
+            name=item["name"],
+            quality=item.get("quality", 75),
+            max_largest_side=item.get("max_largest_side"),
+            max_smallest_side=item.get("max_smallest_side"),
+            output_format=item.get("output_format", "JPEG"),
+            preserve_structure=item.get("preserve_structure", True),
+            jpeg_params=item.get("jpeg_params", {}),
+            webp_params=item.get("webp_params", {}),
+            avif_params=item.get("avif_params", {}),
+            conditions=cond,
+        )
+        profiles.append(profile)
+    return profiles
+
+
+def select_profile(
+    image: Path | str | Image.Image, profiles: Sequence[CompressionProfile]
+) -> CompressionProfile | None:
+    """Return the first profile whose conditions match the image."""
+    file_size: int | None = None
+    if isinstance(image, str | Path):
+        path = Path(image)
+        file_size = path.stat().st_size if path.exists() else None
+        with Image.open(path) as img:
+            width, height = img.size
+            image_format = (img.format or "").upper()
+            has_transparency = "A" in img.getbands() or "transparency" in img.info
+            exif = {ExifTags.TAGS.get(k, str(k)): v for k, v in img.getexif().items()}
+    else:
+        width, height = image.size
+        image_format = (image.format or "").upper()
+        has_transparency = "A" in image.getbands() or "transparency" in image.info
+        exif = {ExifTags.TAGS.get(k, str(k)): v for k, v in image.getexif().items()}
+    for profile in profiles:
+        if profile.conditions.matches(
+            width,
+            height,
+            image_format=image_format,
+            has_transparency=has_transparency,
+            file_size=file_size,
+            exif=exif,
+        ):
+            return profile
+    return None

--- a/service/image_compression.py
+++ b/service/image_compression.py
@@ -68,30 +68,6 @@ class ImageCompressor:
         """Set AVIF-specific compression parameters."""
         self.avif_params = kwargs
 
-    def should_compress_image(self, image_path: Path) -> bool:
-        """Check if the image should be compressed based on its current size."""
-        try:
-            with Image.open(image_path) as img:
-                width, height = img.size
-                largest_side = max(width, height)
-                smallest_side = min(width, height)
-
-                # Check if image needs resizing
-                needs_resize = False
-                if self.max_largest_side is not None and largest_side > self.max_largest_side:
-                    needs_resize = True
-                if self.max_smallest_side is not None and smallest_side > self.max_smallest_side:
-                    needs_resize = True
-
-                # Check if image needs quality compression (for all formats)
-                needs_quality_compression = True  # Always recompress to ensure quality settings
-
-                return needs_resize or needs_quality_compression
-
-        except Exception as e:
-            logger.warning(f"Could not analyze image {image_path}: {e}")
-            return False
-
     def compress_image(self, input_path: Path, output_path: Path) -> Path | None:
         """
         Compress a single image according to the specified parameters.

--- a/service/image_compression.py
+++ b/service/image_compression.py
@@ -273,8 +273,10 @@ class ImageCompressor:
         compressed_paths = []
         failed_files: list[Path] = []
 
-        # Ensure output directory exists
-        output_root.mkdir(parents=True, exist_ok=True)
+        # Ensure output directory does not already exist
+        if output_root.exists():
+            raise FileExistsError(f"Output directory {output_root} already exists")
+        output_root.mkdir(parents=True)
 
         # Walk through input directory
         for file_path in input_root.rglob("*"):

--- a/service/main.py
+++ b/service/main.py
@@ -411,7 +411,9 @@ class MainWindow(QMainWindow):
     def reset_settings(self) -> None:
         """Reset all compression settings to their default values."""
         for panel in self.profile_panels:
-            panel.reset_to_defaults()
+            panel.setParent(None)
+        self.profile_panels.clear()
+        self.add_profile_panel()
         self.log_message("Compression settings reset to defaults")
 
     def select_output_directory(self) -> None:
@@ -432,7 +434,9 @@ class MainWindow(QMainWindow):
 
     def add_profile_panel(self, profile: CompressionProfile | None = None) -> None:
         allow_conditions = len(self.profile_panels) > 0
-        panel = ProfilePanel(f"Profile {len(self.profile_panels) + 1}", allow_conditions=allow_conditions)
+        title = "Default" if not self.profile_panels else f"Profile {len(self.profile_panels) + 1}"
+        panel = ProfilePanel(title, allow_conditions=allow_conditions, removable=allow_conditions)
+        panel.remove_requested.connect(lambda p=panel: self.remove_profile_panel(p))
         self.profile_panels.append(panel)
         self.profiles_layout.addWidget(panel)
         if profile:
@@ -468,6 +472,11 @@ class MainWindow(QMainWindow):
         for profile in profiles:
             self.add_profile_panel(profile)
         self.log_message(f"Loaded {len(profiles)} profiles from {file_name}")
+
+    def remove_profile_panel(self, panel: ProfilePanel) -> None:
+        if panel in self.profile_panels:
+            self.profile_panels.remove(panel)
+            panel.setParent(None)
 
     def start_compression(self) -> None:
         """Start the compression process."""

--- a/service/main.py
+++ b/service/main.py
@@ -13,22 +13,16 @@ from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QFont, QIcon
 from PySide6.QtWidgets import (
     QApplication,
-    QCheckBox,
-    QComboBox,
     QFileDialog,
-    QGridLayout,
     QGroupBox,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QMainWindow,
-    QMenu,
     QMessageBox,
     QProgressBar,
     QPushButton,
     QScrollArea,
-    QSpinBox,
     QTextEdit,
     QToolButton,
     QVBoxLayout,
@@ -48,12 +42,7 @@ from service.image_compression import (
     create_image_pairs,
     save_compression_settings,
 )
-from service.parameters_defaults import (
-    AVIF_DEFAULTS,
-    BASIC_DEFAULTS,
-    JPEG_DEFAULTS,
-    WEBP_DEFAULTS,
-)
+from service.profile_panel import ProfilePanel
 
 
 class CollapsibleBox(QWidget):
@@ -168,9 +157,6 @@ class MainWindow(QMainWindow):
         self.compression_worker: CompressionWorker | None = None
         self.output_directory: Path | None = None
         self.input_directory: Path | None = None
-
-        # Store all parameter widgets for dynamic UI updates
-        self.parameter_widgets: dict[str, dict[str, QWidget]] = {}
 
         self.setup_ui()
         self.setup_connections()
@@ -307,12 +293,17 @@ class MainWindow(QMainWindow):
         header_layout.setContentsMargins(0, 0, 10, 0)
         header_layout.addStretch()
 
-        self.profiles_btn = QPushButton("Profiles")
-        self.profiles_menu = QMenu(self.profiles_btn)
-        self.profiles_menu.addAction("Save", self.save_profiles)
-        self.profiles_menu.addAction("Load", self.load_profiles)
-        self.profiles_btn.setMenu(self.profiles_menu)
-        header_layout.addWidget(self.profiles_btn)
+        self.save_profiles_btn = QPushButton("Save Profiles")
+        self.save_profiles_btn.clicked.connect(self.save_profiles)
+        header_layout.addWidget(self.save_profiles_btn)
+
+        self.load_profiles_btn = QPushButton("Load Profiles")
+        self.load_profiles_btn.clicked.connect(self.load_profiles)
+        header_layout.addWidget(self.load_profiles_btn)
+
+        self.add_profile_btn = QPushButton("Add Profile")
+        self.add_profile_btn.clicked.connect(self.add_profile_panel)
+        header_layout.addWidget(self.add_profile_btn)
 
         self.reset_btn = QPushButton("Reset Settings")
         self.reset_btn.setStyleSheet("""
@@ -334,72 +325,11 @@ class MainWindow(QMainWindow):
         header_layout.addWidget(self.reset_btn)
         self.settings_layout.addLayout(header_layout)
 
-        # Basic settings group
-        self.basic_group = QGroupBox("Basic Settings")
-        self.basic_layout = QGridLayout(self.basic_group)
+        self.profiles_layout = QVBoxLayout()
+        self.settings_layout.addLayout(self.profiles_layout)
 
-        # Quality setting (common for all formats)
-        self.basic_layout.addWidget(QLabel("Quality:"), 0, 0)
-        self.quality_spinbox = QSpinBox()
-        self.quality_spinbox.setRange(1, 100)
-        self.quality_spinbox.setValue(BASIC_DEFAULTS["quality"])
-        self.quality_spinbox.setSuffix("%")
-        self.quality_spinbox.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
-        self.quality_spinbox.setToolTip("Quality level (1-100). Lower values = stronger compression, smaller files")
-        self.basic_layout.addWidget(self.quality_spinbox, 0, 1)
-
-        # Max largest side
-        self.max_largest_checkbox = QCheckBox("Max Largest Side:")
-        self.max_largest_checkbox.setChecked(BASIC_DEFAULTS["max_largest_enabled"])
-        self.max_largest_checkbox.setToolTip("Enable maximum size limit for the largest side")
-        self.basic_layout.addWidget(self.max_largest_checkbox, 1, 0)
-        self.max_largest_spinbox = QSpinBox()
-        self.max_largest_spinbox.setRange(100, 10000)
-        self.max_largest_spinbox.setValue(BASIC_DEFAULTS["max_largest_side"])
-        self.max_largest_spinbox.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
-        self.max_largest_spinbox.setToolTip("Maximum size of the largest side in pixels")
-        self.max_largest_checkbox.toggled.connect(self.max_largest_spinbox.setEnabled)
-        self.max_largest_spinbox.setEnabled(self.max_largest_checkbox.isChecked())
-        self.basic_layout.addWidget(self.max_largest_spinbox, 1, 1)
-
-        # Max smallest side
-        self.max_smallest_checkbox = QCheckBox("Max Smallest Side:")
-        self.max_smallest_checkbox.setChecked(BASIC_DEFAULTS["max_smallest_enabled"])
-        self.max_smallest_checkbox.setToolTip("Enable maximum size limit for the smallest side")
-        self.basic_layout.addWidget(self.max_smallest_checkbox, 2, 0)
-        self.max_smallest_spinbox = QSpinBox()
-        self.max_smallest_spinbox.setRange(100, 10000)
-        self.max_smallest_spinbox.setValue(BASIC_DEFAULTS["max_smallest_side"])
-        self.max_smallest_spinbox.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
-        self.max_smallest_spinbox.setToolTip("Maximum size of the smallest side in pixels")
-        self.max_smallest_checkbox.toggled.connect(self.max_smallest_spinbox.setEnabled)
-        self.max_smallest_spinbox.setEnabled(self.max_smallest_checkbox.isChecked())
-        self.basic_layout.addWidget(self.max_smallest_spinbox, 2, 1)
-
-        # Output format
-        self.basic_layout.addWidget(QLabel("Output Format:"), 3, 0)
-        self.format_combo = QComboBox()
-        self.format_combo.addItems(["JPEG", "WebP", "AVIF"])
-        self.format_combo.setCurrentText(BASIC_DEFAULTS["output_format"])
-        self.format_combo.setStyleSheet("padding: 5px; border: 1px solid #ccc; border-radius: 4px;")
-        self.format_combo.setToolTip("Output image format")
-        self.basic_layout.addWidget(self.format_combo, 3, 1)
-
-        # Preserve original structure
-        self.preserve_structure_checkbox = QCheckBox("Preserve folder structure")
-        self.preserve_structure_checkbox.setChecked(BASIC_DEFAULTS["preserve_structure"])
-        self.preserve_structure_checkbox.setToolTip(
-            "Keep original folder structure or flatten all files to output directory"
-        )
-        self.basic_layout.addWidget(self.preserve_structure_checkbox, 4, 0, 1, 2)
-
-        self.settings_layout.addWidget(self.basic_group)
-
-        self.advanced_box = CollapsibleBox("Advanced Settings")
-        self.settings_layout.addWidget(self.advanced_box)
-
-        # Format-specific settings groups
-        self.create_format_specific_settings()
+        self.profile_panels: list[ProfilePanel] = []
+        self.add_profile_panel()
 
         scroll_area.setWidget(self.settings_container)
         main_layout.addWidget(scroll_area)
@@ -489,220 +419,6 @@ class MainWindow(QMainWindow):
 
         main_layout.addWidget(log_group)
 
-        # Initialize format-specific settings visibility
-        self.update_format_specific_settings()
-
-    def create_format_specific_settings(self) -> None:
-        # Store all widgets for easy access
-        self.parameter_widgets = {
-            "jpeg": self._setup_advanced_for_jpeg(),
-            "webp": self._setup_advanced_for_webp(),
-            "avif": self._setup_advanced_for_avif(),
-        }
-
-    def _setup_advanced_for_jpeg(self) -> dict:
-        # JPEG Settings
-        self.jpeg_group = QGroupBox("JPEG Advanced Settings")
-        self.jpeg_group.setVisible(False)
-        jpeg_layout = QGridLayout(self.jpeg_group)
-
-        # Progressive
-        jpeg_layout.addWidget(QLabel("Progressive:"), 0, 0)
-        self.jpeg_progressive = QCheckBox()
-        self.jpeg_progressive.setChecked(JPEG_DEFAULTS["progressive"])
-        self.jpeg_progressive.setToolTip("Progressive JPEG encoding. Sometimes reduces file size")
-        jpeg_layout.addWidget(self.jpeg_progressive, 0, 1)
-
-        # Subsampling
-        jpeg_layout.addWidget(QLabel("Subsampling:"), 1, 0)
-        self.jpeg_subsampling = QComboBox()
-        self.jpeg_subsampling.addItems(["Auto (-1)", "4:4:4 (0)", "4:2:2 (1)", "4:2:0 (2)"])
-        self.jpeg_subsampling.setCurrentText(JPEG_DEFAULTS["subsampling"])
-        self.jpeg_subsampling.setToolTip("Color subsampling. 4:4:4 = best quality, 4:2:0 = best compression")
-        jpeg_layout.addWidget(self.jpeg_subsampling, 1, 1)
-
-        # Optimize
-        jpeg_layout.addWidget(QLabel("Optimize:"), 2, 0)
-        self.jpeg_optimize = QCheckBox()
-        self.jpeg_optimize.setChecked(JPEG_DEFAULTS["optimize"])
-        self.jpeg_optimize.setToolTip("Huffman optimization for better compression")
-        jpeg_layout.addWidget(self.jpeg_optimize, 2, 1)
-
-        # Smooth
-        jpeg_layout.addWidget(QLabel("Smooth:"), 3, 0)
-        self.jpeg_smooth = QSpinBox()
-        self.jpeg_smooth.setRange(0, 100)
-        self.jpeg_smooth.setValue(JPEG_DEFAULTS["smooth"])
-        self.jpeg_smooth.setToolTip("Light smoothing (0-100). Reduces noise for better compression")
-        jpeg_layout.addWidget(self.jpeg_smooth, 3, 1)
-
-        # Keep RGB
-        jpeg_layout.addWidget(QLabel("Keep RGB:"), 4, 0)
-        self.jpeg_keep_rgb = QCheckBox()
-        self.jpeg_keep_rgb.setChecked(JPEG_DEFAULTS["keep_rgb"])
-        self.jpeg_keep_rgb.setToolTip("Save in RGB instead of YCbCr. May increase size but removes color transitions")
-        jpeg_layout.addWidget(self.jpeg_keep_rgb, 4, 1)
-
-        self.advanced_box.add_widget(self.jpeg_group)
-        return {
-            "progressive": self.jpeg_progressive,
-            "subsampling": self.jpeg_subsampling,
-            "optimize": self.jpeg_optimize,
-            "smooth": self.jpeg_smooth,
-            "keep_rgb": self.jpeg_keep_rgb,
-        }
-
-    def _setup_advanced_for_webp(self) -> dict:
-        # WebP Settings
-        self.webp_group = QGroupBox("WebP Advanced Settings")
-        self.webp_group.setVisible(False)
-        webp_layout = QGridLayout(self.webp_group)
-
-        # Lossless
-        webp_layout.addWidget(QLabel("Lossless:"), 0, 0)
-        self.webp_lossless = QCheckBox()
-        self.webp_lossless.setChecked(WEBP_DEFAULTS["lossless"])
-        self.webp_lossless.setToolTip("Lossless compression. Radically changes compression method")
-        webp_layout.addWidget(self.webp_lossless, 0, 1)
-
-        # Method
-        webp_layout.addWidget(QLabel("Method:"), 1, 0)
-        self.webp_method = QSpinBox()
-        self.webp_method.setRange(0, 6)
-        self.webp_method.setValue(WEBP_DEFAULTS["method"])
-        self.webp_method.setToolTip("Compression method (0-6). Slower = better compression at same quality")
-        webp_layout.addWidget(self.webp_method, 1, 1)
-
-        # Alpha Quality
-        webp_layout.addWidget(QLabel("Alpha Quality:"), 2, 0)
-        self.webp_alpha_quality = QSpinBox()
-        self.webp_alpha_quality.setRange(0, 100)
-        self.webp_alpha_quality.setValue(WEBP_DEFAULTS["alpha_quality"])
-        self.webp_alpha_quality.setToolTip("Quality of alpha channel in lossy mode")
-        webp_layout.addWidget(self.webp_alpha_quality, 2, 1)
-
-        # Exact
-        webp_layout.addWidget(QLabel("Exact:"), 3, 0)
-        self.webp_exact = QCheckBox()
-        self.webp_exact.setChecked(WEBP_DEFAULTS["exact"])
-        self.webp_exact.setToolTip("Save RGB under transparency. Increases size but improves quality")
-        webp_layout.addWidget(self.webp_exact, 3, 1)
-        self.advanced_box.add_widget(self.webp_group)
-
-        return {
-            "lossless": self.webp_lossless,
-            "method": self.webp_method,
-            "alpha_quality": self.webp_alpha_quality,
-            "exact": self.webp_exact,
-        }
-
-    def _setup_advanced_for_avif(self) -> dict:
-        # AVIF Settings
-        self.avif_group = QGroupBox("AVIF Advanced Settings")
-        self.avif_group.setVisible(False)
-        avif_layout = QGridLayout(self.avif_group)
-
-        # Subsampling
-        avif_layout.addWidget(QLabel("Subsampling:"), 0, 0)
-        self.avif_subsampling = QComboBox()
-        self.avif_subsampling.addItems(["4:2:0", "4:2:2", "4:4:4", "4:0:0"])
-        self.avif_subsampling.setCurrentText(AVIF_DEFAULTS["subsampling"])
-        self.avif_subsampling.setToolTip("Color subsampling. 4:4:4 = best quality, 4:2:0 = best compression")
-        avif_layout.addWidget(self.avif_subsampling, 0, 1)
-
-        # Speed
-        avif_layout.addWidget(QLabel("Speed:"), 1, 0)
-        self.avif_speed = QSpinBox()
-        self.avif_speed.setRange(0, 10)
-        self.avif_speed.setValue(AVIF_DEFAULTS["speed"])
-        self.avif_speed.setToolTip("Encoding speed (0-10). 0 = slower/better, 10 = faster/worse")
-        avif_layout.addWidget(self.avif_speed, 1, 1)
-
-        # Codec
-        avif_layout.addWidget(QLabel("Codec:"), 2, 0)
-        self.avif_codec = QComboBox()
-        self.avif_codec.addItems(["auto", "aom", "rav1e", "svt"])
-        self.avif_codec.setCurrentText(AVIF_DEFAULTS["codec"])
-        self.avif_codec.setToolTip("AV1 encoder to use (if available)")
-        avif_layout.addWidget(self.avif_codec, 2, 1)
-
-        # Range
-        avif_layout.addWidget(QLabel("Range:"), 3, 0)
-        self.avif_range = QComboBox()
-        self.avif_range.addItems(["full", "limited"])
-        self.avif_range.setCurrentText(AVIF_DEFAULTS["range"])
-        self.avif_range.setToolTip("Tonal range")
-        avif_layout.addWidget(self.avif_range, 3, 1)
-
-        # QMin
-        avif_layout.addWidget(QLabel("QMin:"), 4, 0)
-        self.avif_qmin = QSpinBox()
-        self.avif_qmin.setRange(-1, 63)
-        self.avif_qmin.setValue(AVIF_DEFAULTS["qmin"])
-        self.avif_qmin.setToolTip("Minimum quantizer (-1 = auto, 0-63 = hard lower bound)")
-        avif_layout.addWidget(self.avif_qmin, 4, 1)
-
-        # QMax
-        avif_layout.addWidget(QLabel("QMax:"), 5, 0)
-        self.avif_qmax = QSpinBox()
-        self.avif_qmax.setRange(-1, 63)
-        self.avif_qmax.setValue(AVIF_DEFAULTS["qmax"])
-        self.avif_qmax.setToolTip("Maximum quantizer (-1 = auto, 0-63 = upper bound)")
-        avif_layout.addWidget(self.avif_qmax, 5, 1)
-
-        # Auto Tiling
-        avif_layout.addWidget(QLabel("Auto Tiling:"), 6, 0)
-        self.avif_autotiling = QCheckBox()
-        self.avif_autotiling.setChecked(AVIF_DEFAULTS["autotiling"])
-        self.avif_autotiling.setToolTip("Automatic tiling for better decoding speed")
-        avif_layout.addWidget(self.avif_autotiling, 6, 1)
-
-        # Tile Rows
-        avif_layout.addWidget(QLabel("Tile Rows (log2):"), 7, 0)
-        self.avif_tile_rows = QSpinBox()
-        self.avif_tile_rows.setRange(0, 6)
-        self.avif_tile_rows.setValue(AVIF_DEFAULTS["tile_rows"])
-        self.avif_tile_rows.setToolTip("Explicit tile rows (if auto tiling = false)")
-        avif_layout.addWidget(self.avif_tile_rows, 7, 1)
-
-        # Tile Cols
-        avif_layout.addWidget(QLabel("Tile Cols (log2):"), 8, 0)
-        self.avif_tile_cols = QSpinBox()
-        self.avif_tile_cols.setRange(0, 6)
-        self.avif_tile_cols.setValue(AVIF_DEFAULTS["tile_cols"])
-        self.avif_tile_cols.setToolTip("Explicit tile columns (if auto tiling = false)")
-        avif_layout.addWidget(self.avif_tile_cols, 8, 1)
-        self.advanced_box.add_widget(self.avif_group)
-
-        return {
-            "subsampling": self.avif_subsampling,
-            "speed": self.avif_speed,
-            "codec": self.avif_codec,
-            "range": self.avif_range,
-            "qmin": self.avif_qmin,
-            "qmax": self.avif_qmax,
-            "autotiling": self.avif_autotiling,
-            "tile_rows": self.avif_tile_rows,
-            "tile_cols": self.avif_tile_cols,
-        }
-
-    def update_format_specific_settings(self) -> None:
-        """Update visibility of format-specific settings based on selected format."""
-        format_name = self.format_combo.currentText().lower()
-
-        # Hide all groups first
-        self.jpeg_group.setVisible(False)
-        self.webp_group.setVisible(False)
-        self.avif_group.setVisible(False)
-
-        # Show only the relevant group
-        if format_name == "jpeg":
-            self.jpeg_group.setVisible(True)
-        elif format_name == "webp":
-            self.webp_group.setVisible(True)
-        elif format_name == "avif":
-            self.avif_group.setVisible(True)
-
     def setup_connections(self) -> None:
         """Set up signal connections."""
         self.select_input_btn.clicked.connect(self.select_input_directory)
@@ -711,7 +427,6 @@ class MainWindow(QMainWindow):
         self.compress_btn.clicked.connect(self.start_compression)
         self.compare_btn.clicked.connect(self.show_comparison)
         self.reset_btn.clicked.connect(self.reset_settings)
-        self.format_combo.currentTextChanged.connect(self.update_format_specific_settings)
 
     def select_input_directory(self) -> None:
         """Select input directory for compression."""
@@ -731,43 +446,8 @@ class MainWindow(QMainWindow):
 
     def reset_settings(self) -> None:
         """Reset all compression settings to their default values."""
-        # Basic settings
-        self.quality_spinbox.setValue(BASIC_DEFAULTS["quality"])
-        self.max_largest_checkbox.setChecked(BASIC_DEFAULTS["max_largest_enabled"])
-        self.max_largest_spinbox.setValue(BASIC_DEFAULTS["max_largest_side"])
-        self.max_largest_spinbox.setEnabled(BASIC_DEFAULTS["max_largest_enabled"])
-        self.max_smallest_checkbox.setChecked(BASIC_DEFAULTS["max_smallest_enabled"])
-        self.max_smallest_spinbox.setValue(BASIC_DEFAULTS["max_smallest_side"])
-        self.max_smallest_spinbox.setEnabled(BASIC_DEFAULTS["max_smallest_enabled"])
-        self.format_combo.setCurrentText(BASIC_DEFAULTS["output_format"])
-        self.preserve_structure_checkbox.setChecked(BASIC_DEFAULTS["preserve_structure"])
-
-        # JPEG specific
-        self.jpeg_progressive.setChecked(JPEG_DEFAULTS["progressive"])
-        self.jpeg_subsampling.setCurrentText(JPEG_DEFAULTS["subsampling"])
-        self.jpeg_optimize.setChecked(JPEG_DEFAULTS["optimize"])
-        self.jpeg_smooth.setValue(JPEG_DEFAULTS["smooth"])
-        self.jpeg_keep_rgb.setChecked(JPEG_DEFAULTS["keep_rgb"])
-
-        # WebP specific
-        self.webp_lossless.setChecked(WEBP_DEFAULTS["lossless"])
-        self.webp_method.setValue(WEBP_DEFAULTS["method"])
-        self.webp_alpha_quality.setValue(WEBP_DEFAULTS["alpha_quality"])
-        self.webp_exact.setChecked(WEBP_DEFAULTS["exact"])
-
-        # AVIF specific
-        self.avif_subsampling.setCurrentText(AVIF_DEFAULTS["subsampling"])
-        self.avif_speed.setValue(AVIF_DEFAULTS["speed"])
-        self.avif_codec.setCurrentText(AVIF_DEFAULTS["codec"])
-        self.avif_range.setCurrentText(AVIF_DEFAULTS["range"])
-        self.avif_qmin.setValue(AVIF_DEFAULTS["qmin"])
-        self.avif_qmax.setValue(AVIF_DEFAULTS["qmax"])
-        self.avif_autotiling.setChecked(AVIF_DEFAULTS["autotiling"])
-        self.avif_tile_rows.setValue(AVIF_DEFAULTS["tile_rows"])
-        self.avif_tile_cols.setValue(AVIF_DEFAULTS["tile_cols"])
-
-        # Update UI state
-        self.update_format_specific_settings()
+        for panel in self.profile_panels:
+            panel.reset_to_defaults()
         self.log_message("Compression settings reset to defaults")
 
     def select_output_directory(self) -> None:
@@ -786,181 +466,28 @@ class MainWindow(QMainWindow):
         """Update stored output directory when text changes."""
         self.output_directory = Path(text) if text else None
 
+    def add_profile_panel(self, profile: CompressionProfile | None = None) -> None:
+        panel = ProfilePanel(f"Profile {len(self.profile_panels) + 1}")
+        self.profile_panels.append(panel)
+        self.profiles_layout.addWidget(panel)
+        if profile:
+            panel.apply_profile(profile)
+
     def get_compression_parameters(self) -> dict[str, Any]:
-        """Get all compression parameters from UI."""
-        format_name = self.format_combo.currentText().lower()
-
-        # Ensure output directory reflects current text
-        if self.output_dir_edit.text():
-            self.output_directory = Path(self.output_dir_edit.text())
-
-        # Basic parameters
-        params = {
-            "quality": self.quality_spinbox.value(),
-            "max_largest_side": self.max_largest_spinbox.value() if self.max_largest_checkbox.isChecked() else None,
-            "max_smallest_side": self.max_smallest_spinbox.value() if self.max_smallest_checkbox.isChecked() else None,
-            "preserve_structure": self.preserve_structure_checkbox.isChecked(),
-            "output_format": self.format_combo.currentText(),
-            "input_directory": str(self.input_directory),
-            "output_directory": str(self.output_directory),
-        }
-
-        # Format-specific parameters
-        if format_name == "jpeg":
-            params.update(
-                {
-                    "progressive": self.jpeg_progressive.isChecked(),
-                    "subsampling": self._get_jpeg_subsampling_value(),
-                    "optimize": self.jpeg_optimize.isChecked(),
-                    "smooth": self.jpeg_smooth.value(),
-                    "keep_rgb": self.jpeg_keep_rgb.isChecked(),
-                }
-            )
-        elif format_name == "webp":
-            params.update(
-                {
-                    "lossless": self.webp_lossless.isChecked(),
-                    "method": self.webp_method.value(),
-                    "alpha_quality": self.webp_alpha_quality.value(),
-                    "exact": self.webp_exact.isChecked(),
-                }
-            )
-        elif format_name == "avif":
-            params.update(
-                {
-                    "subsampling": self.avif_subsampling.currentText(),
-                    "speed": self.avif_speed.value(),
-                    "codec": self.avif_codec.currentText(),
-                    "range": self.avif_range.currentText(),
-                    "qmin": self.avif_qmin.value(),
-                    "qmax": self.avif_qmax.value(),
-                    "autotiling": self.avif_autotiling.isChecked(),
-                    "tile_rows": self.avif_tile_rows.value(),
-                    "tile_cols": self.avif_tile_cols.value(),
-                }
-            )
-
+        if not self.profile_panels:
+            return {}
+        params = self.profile_panels[0].get_parameters()
+        params["input_directory"] = str(self.input_directory)
+        params["output_directory"] = str(self.output_directory)
         return params
 
-    def _get_jpeg_subsampling_value(self) -> int | str:
-        """Convert JPEG subsampling combo text to actual value."""
-        text = self.jpeg_subsampling.currentText()
-        if "4:4:4" in text:
-            return 0
-        if "4:2:2" in text:
-            return 1
-        if "4:2:0" in text:
-            return 2
-        return -1  # Auto
-
-    def _set_jpeg_subsampling_value(self, value: int | str) -> None:
-        mapping = {
-            -1: "Auto (-1)",
-            0: "4:4:4 (0)",
-            1: "4:2:2 (1)",
-            2: "4:2:0 (2)",
-        }
-        key = int(value) if isinstance(value, str) else value
-        self.jpeg_subsampling.setCurrentText(mapping.get(key, "Auto (-1)"))
-
-    def _build_profile_from_params(self, name: str, params: dict[str, Any]) -> CompressionProfile:
-        format_name = params["output_format"].lower()
-        profile = CompressionProfile(
-            name=name,
-            quality=params["quality"],
-            max_largest_side=params["max_largest_side"],
-            max_smallest_side=params["max_smallest_side"],
-            output_format=params["output_format"],
-            preserve_structure=params["preserve_structure"],
-        )
-        if format_name == "jpeg":
-            profile.jpeg_params = {
-                "progressive": params.get("progressive", False),
-                "subsampling": params.get("subsampling", -1),
-                "optimize": params.get("optimize", False),
-                "smooth": params.get("smooth", 0),
-                "keep_rgb": params.get("keep_rgb", False),
-            }
-        elif format_name == "webp":
-            profile.webp_params = {
-                "lossless": params.get("lossless", False),
-                "method": params.get("method", 4),
-                "alpha_quality": params.get("alpha_quality", 100),
-                "exact": params.get("exact", False),
-            }
-        elif format_name == "avif":
-            profile.avif_params = {
-                "subsampling": params.get("subsampling", "4:2:0"),
-                "speed": params.get("speed", 6),
-                "codec": params.get("codec", "auto"),
-                "range": params.get("range", "full"),
-                "qmin": params.get("qmin", -1),
-                "qmax": params.get("qmax", -1),
-                "autotiling": params.get("autotiling", True),
-                "tile_rows": params.get("tile_rows", 0),
-                "tile_cols": params.get("tile_cols", 0),
-            }
-        return profile
-
-    def apply_profile(self, profile: CompressionProfile) -> None:
-        self.quality_spinbox.setValue(profile.quality)
-
-        if profile.max_largest_side is not None:
-            self.max_largest_checkbox.setChecked(True)
-            self.max_largest_spinbox.setValue(profile.max_largest_side)
-        else:
-            self.max_largest_checkbox.setChecked(False)
-        self.max_largest_spinbox.setEnabled(profile.max_largest_side is not None)
-
-        if profile.max_smallest_side is not None:
-            self.max_smallest_checkbox.setChecked(True)
-            self.max_smallest_spinbox.setValue(profile.max_smallest_side)
-        else:
-            self.max_smallest_checkbox.setChecked(False)
-        self.max_smallest_spinbox.setEnabled(profile.max_smallest_side is not None)
-
-        self.format_combo.setCurrentText(profile.output_format)
-        self.preserve_structure_checkbox.setChecked(profile.preserve_structure)
-
-        fmt = profile.output_format.lower()
-        if fmt == "jpeg":
-            p = profile.jpeg_params
-            self.jpeg_progressive.setChecked(p.get("progressive", False))
-            self._set_jpeg_subsampling_value(p.get("subsampling", -1))
-            self.jpeg_optimize.setChecked(p.get("optimize", False))
-            self.jpeg_smooth.setValue(p.get("smooth", 0))
-            self.jpeg_keep_rgb.setChecked(p.get("keep_rgb", False))
-        elif fmt == "webp":
-            p = profile.webp_params
-            self.webp_lossless.setChecked(p.get("lossless", False))
-            self.webp_method.setValue(p.get("method", 4))
-            self.webp_alpha_quality.setValue(p.get("alpha_quality", 100))
-            self.webp_exact.setChecked(p.get("exact", False))
-        elif fmt == "avif":
-            p = profile.avif_params
-            self.avif_subsampling.setCurrentText(p.get("subsampling", "4:2:0"))
-            self.avif_speed.setValue(p.get("speed", 6))
-            self.avif_codec.setCurrentText(p.get("codec", "auto"))
-            self.avif_range.setCurrentText(p.get("range", "full"))
-            self.avif_qmin.setValue(p.get("qmin", -1))
-            self.avif_qmax.setValue(p.get("qmax", -1))
-            self.avif_autotiling.setChecked(p.get("autotiling", True))
-            self.avif_tile_rows.setValue(p.get("tile_rows", 0))
-            self.avif_tile_cols.setValue(p.get("tile_cols", 0))
-
-        self.update_format_specific_settings()
-
     def save_profiles(self) -> None:
-        params = self.get_compression_parameters()
-        name, ok = QInputDialog.getText(self, "Save Profile", "Profile name:")
-        if not ok or not name:
-            return
-        profile = self._build_profile_from_params(name, params)
         file_name, _ = QFileDialog.getSaveFileName(self, "Save Profiles", "profiles.json", "JSON Files (*.json)")
         if not file_name:
             return
-        save_profiles([profile], Path(file_name))
-        self.log_message(f"Profile '{name}' saved to {file_name}")
+        profiles = [panel.to_profile() for panel in self.profile_panels]
+        save_profiles(profiles, Path(file_name))
+        self.log_message(f"Saved {len(profiles)} profiles to {file_name}")
 
     def load_profiles(self) -> None:
         file_name, _ = QFileDialog.getOpenFileName(self, "Load Profiles", "", "JSON Files (*.json)")
@@ -970,13 +497,12 @@ class MainWindow(QMainWindow):
         if not profiles:
             QMessageBox.warning(self, "Warning", "No profiles found in file.")
             return
-        names = [p.name for p in profiles]
-        name, ok = QInputDialog.getItem(self, "Select Profile", "Profile:", names, 0, False)
-        if not ok:
-            return
-        profile = next(p for p in profiles if p.name == name)
-        self.apply_profile(profile)
-        self.log_message(f"Profile '{name}' loaded from {file_name}")
+        for panel in self.profile_panels:
+            panel.setParent(None)
+        self.profile_panels.clear()
+        for profile in profiles:
+            self.add_profile_panel(profile)
+        self.log_message(f"Loaded {len(profiles)} profiles from {file_name}")
 
     def start_compression(self) -> None:
         """Start the compression process."""
@@ -1005,36 +531,6 @@ class MainWindow(QMainWindow):
             preserve_structure=compression_params["preserve_structure"],
             output_format=compression_params["output_format"],
         )
-
-        # Set format-specific parameters
-        format_name = compression_params["output_format"].lower()
-        if format_name == "jpeg":
-            compressor.set_jpeg_parameters(
-                progressive=compression_params.get("progressive", False),
-                subsampling=compression_params.get("subsampling", -1),
-                optimize=compression_params.get("optimize", False),
-                smooth=compression_params.get("smooth", 0),
-                keep_rgb=compression_params.get("keep_rgb", False),
-            )
-        elif format_name == "webp":
-            compressor.set_webp_parameters(
-                lossless=compression_params.get("lossless", False),
-                method=compression_params.get("method", 4),
-                alpha_quality=compression_params.get("alpha_quality", 100),
-                exact=compression_params.get("exact", False),
-            )
-        elif format_name == "avif":
-            compressor.set_avif_parameters(
-                subsampling=compression_params.get("subsampling", "4:2:0"),
-                speed=compression_params.get("speed", 6),
-                codec=compression_params.get("codec", "auto"),
-                range=compression_params.get("range", "full"),
-                qmin=compression_params.get("qmin", -1),
-                qmax=compression_params.get("qmax", -1),
-                autotiling=compression_params.get("autotiling", True),
-                tile_rows=compression_params.get("tile_rows", 0),
-                tile_cols=compression_params.get("tile_cols", 0),
-            )
 
         # Store all parameters for the worker
         compression_settings = compression_params.copy()

--- a/service/profile_panel.py
+++ b/service/profile_panel.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from PySide6.QtCore import QEvent, QObject, Signal
 from PySide6.QtWidgets import (
+    QApplication,
     QCheckBox,
     QComboBox,
     QDoubleSpinBox,
@@ -71,8 +72,11 @@ def subsampling_label(value: int) -> str:
 
 
 class _WheelBlocker(QObject):
-    def eventFilter(self, _obj: QObject, event: QEvent) -> bool:
-        return event.type() == QEvent.Type.Wheel
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Wheel:
+            QApplication.sendEvent(obj.parent(), event)
+            return True
+        return False
 
 
 class ProfilePanel(QWidget):

--- a/service/profile_panel.py
+++ b/service/profile_panel.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from service.compression_profiles import CompressionProfile, ProfileConditions
+from service.parameters_defaults import BASIC_DEFAULTS
+
+
+class ProfilePanel(QWidget):
+    """Panel containing compression parameters and matching conditions."""
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.title = title
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Profile name
+        name_layout = QHBoxLayout()
+        name_layout.addWidget(QLabel("Name:"))
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText(self.title)
+        name_layout.addWidget(self.name_edit)
+        layout.addLayout(name_layout)
+
+        # Compression settings
+        self.basic_group = QGroupBox("Compression Settings")
+        grid = QGridLayout(self.basic_group)
+
+        grid.addWidget(QLabel("Quality:"), 0, 0)
+        self.quality = QSpinBox()
+        self.quality.setRange(1, 100)
+        self.quality.setValue(BASIC_DEFAULTS["quality"])
+        self.quality.setSuffix("%")
+        grid.addWidget(self.quality, 0, 1)
+
+        self.max_largest_cb = QCheckBox("Max largest side:")
+        self.max_largest_cb.setChecked(BASIC_DEFAULTS["max_largest_enabled"])
+        grid.addWidget(self.max_largest_cb, 1, 0)
+        self.max_largest = QSpinBox()
+        self.max_largest.setRange(1, 10000)
+        self.max_largest.setValue(BASIC_DEFAULTS["max_largest_side"])
+        self.max_largest.setEnabled(BASIC_DEFAULTS["max_largest_enabled"])
+        grid.addWidget(self.max_largest, 1, 1)
+
+        self.max_smallest_cb = QCheckBox("Max smallest side:")
+        self.max_smallest_cb.setChecked(BASIC_DEFAULTS["max_smallest_enabled"])
+        grid.addWidget(self.max_smallest_cb, 2, 0)
+        self.max_smallest = QSpinBox()
+        self.max_smallest.setRange(1, 10000)
+        self.max_smallest.setValue(BASIC_DEFAULTS["max_smallest_side"])
+        self.max_smallest.setEnabled(BASIC_DEFAULTS["max_smallest_enabled"])
+        grid.addWidget(self.max_smallest, 2, 1)
+
+        grid.addWidget(QLabel("Format:"), 3, 0)
+        self.format_combo = QComboBox()
+        self.format_combo.addItems(["JPEG", "WEBP", "AVIF"])
+        self.format_combo.setCurrentText(BASIC_DEFAULTS["output_format"])
+        grid.addWidget(self.format_combo, 3, 1)
+
+        self.preserve_cb = QCheckBox("Preserve folder structure")
+        self.preserve_cb.setChecked(BASIC_DEFAULTS["preserve_structure"])
+        grid.addWidget(self.preserve_cb, 4, 0, 1, 2)
+
+        layout.addWidget(self.basic_group)
+
+        # Conditions sub-panel
+        self.conditions_group = QGroupBox("Conditions")
+        cond_grid = QGridLayout(self.conditions_group)
+
+        self.cond_smallest_cb = QCheckBox("Max smallest side:")
+        cond_grid.addWidget(self.cond_smallest_cb, 0, 0)
+        self.cond_smallest = QSpinBox()
+        self.cond_smallest.setRange(1, 10000)
+        self.cond_smallest.setEnabled(False)
+        cond_grid.addWidget(self.cond_smallest, 0, 1)
+        self.cond_smallest_cb.stateChanged.connect(lambda s: self.cond_smallest.setEnabled(bool(s)))
+
+        cond_grid.addWidget(QLabel("Orientation:"), 1, 0)
+        self.orientation_combo = QComboBox()
+        self.orientation_combo.addItems(["Any", "landscape", "portrait", "square"])
+        cond_grid.addWidget(self.orientation_combo, 1, 1)
+
+        layout.addWidget(self.conditions_group)
+
+    # ------------------------------------------------------------------
+    def get_parameters(self) -> dict[str, Any]:
+        """Return compression parameters from the panel."""
+        return {
+            "quality": self.quality.value(),
+            "max_largest_side": self.max_largest.value() if self.max_largest_cb.isChecked() else None,
+            "max_smallest_side": self.max_smallest.value() if self.max_smallest_cb.isChecked() else None,
+            "preserve_structure": self.preserve_cb.isChecked(),
+            "output_format": self.format_combo.currentText(),
+        }
+
+    def get_conditions(self) -> ProfileConditions:
+        """Return matching conditions configured in the panel."""
+        return ProfileConditions(
+            max_input_smallest_side=self.cond_smallest.value() if self.cond_smallest_cb.isChecked() else None,
+            orientation=None if self.orientation_combo.currentText() == "Any" else self.orientation_combo.currentText(),
+        )
+
+    def to_profile(self) -> CompressionProfile:
+        params = self.get_parameters()
+        profile = CompressionProfile(
+            name=self.name_edit.text() or self.title,
+            quality=params["quality"],
+            max_largest_side=params["max_largest_side"],
+            max_smallest_side=params["max_smallest_side"],
+            output_format=params["output_format"],
+            preserve_structure=params["preserve_structure"],
+        )
+        profile.conditions = self.get_conditions()
+        return profile
+
+    def apply_profile(self, profile: CompressionProfile) -> None:
+        self.name_edit.setText(profile.name)
+        self.quality.setValue(profile.quality)
+
+        if profile.max_largest_side is not None:
+            self.max_largest_cb.setChecked(True)
+            self.max_largest.setValue(profile.max_largest_side)
+        else:
+            self.max_largest_cb.setChecked(False)
+            self.max_largest.setEnabled(False)
+
+        if profile.max_smallest_side is not None:
+            self.max_smallest_cb.setChecked(True)
+            self.max_smallest.setValue(profile.max_smallest_side)
+        else:
+            self.max_smallest_cb.setChecked(False)
+            self.max_smallest.setEnabled(False)
+
+        self.format_combo.setCurrentText(profile.output_format)
+        self.preserve_cb.setChecked(profile.preserve_structure)
+
+        cond = profile.conditions
+        if cond.max_input_smallest_side is not None:
+            self.cond_smallest_cb.setChecked(True)
+            self.cond_smallest.setValue(cond.max_input_smallest_side)
+        else:
+            self.cond_smallest_cb.setChecked(False)
+            self.cond_smallest.setEnabled(False)
+
+        if cond.orientation:
+            self.orientation_combo.setCurrentText(cond.orientation)
+        else:
+            self.orientation_combo.setCurrentText("Any")
+
+    def reset_to_defaults(self) -> None:
+        self.name_edit.clear()
+        self.quality.setValue(BASIC_DEFAULTS["quality"])
+
+        self.max_largest_cb.setChecked(BASIC_DEFAULTS["max_largest_enabled"])
+        self.max_largest.setValue(BASIC_DEFAULTS["max_largest_side"])
+        self.max_largest.setEnabled(BASIC_DEFAULTS["max_largest_enabled"])
+
+        self.max_smallest_cb.setChecked(BASIC_DEFAULTS["max_smallest_enabled"])
+        self.max_smallest.setValue(BASIC_DEFAULTS["max_smallest_side"])
+        self.max_smallest.setEnabled(BASIC_DEFAULTS["max_smallest_enabled"])
+
+        self.format_combo.setCurrentText(BASIC_DEFAULTS["output_format"])
+        self.preserve_cb.setChecked(BASIC_DEFAULTS["preserve_structure"])
+
+        self.cond_smallest_cb.setChecked(False)
+        self.cond_smallest.setEnabled(False)
+        self.orientation_combo.setCurrentText("Any")

--- a/service/profile_panel.py
+++ b/service/profile_panel.py
@@ -5,6 +5,7 @@ from typing import Any
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
@@ -15,16 +16,23 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from service.collapsible_box import CollapsibleBox
 from service.compression_profiles import CompressionProfile, ProfileConditions
-from service.parameters_defaults import BASIC_DEFAULTS
+from service.parameters_defaults import (
+    AVIF_DEFAULTS,
+    BASIC_DEFAULTS,
+    JPEG_DEFAULTS,
+    WEBP_DEFAULTS,
+)
 
 
 class ProfilePanel(QWidget):
     """Panel containing compression parameters and matching conditions."""
 
-    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+    def __init__(self, title: str, *, allow_conditions: bool = True, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.title = title
+        self.allow_conditions = allow_conditions
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -80,24 +88,195 @@ class ProfilePanel(QWidget):
 
         layout.addWidget(self.basic_group)
 
+        # Advanced settings
+        self.advanced_box = CollapsibleBox("Advanced Settings")
+
+        # JPEG settings
+        jpeg_group = QGroupBox("JPEG")
+        jpeg_grid = QGridLayout(jpeg_group)
+        self.jpeg_progressive = QCheckBox("Progressive")
+        self.jpeg_progressive.setChecked(JPEG_DEFAULTS["progressive"])
+        jpeg_grid.addWidget(self.jpeg_progressive, 0, 0, 1, 2)
+        jpeg_grid.addWidget(QLabel("Subsampling:"), 1, 0)
+        self.jpeg_subsampling = QComboBox()
+        self.jpeg_subsampling.addItems(["Auto (-1)", "4:4:4 (0)", "4:2:2 (1)", "4:2:0 (2)"])
+        self.jpeg_subsampling.setCurrentText(JPEG_DEFAULTS["subsampling"])
+        jpeg_grid.addWidget(self.jpeg_subsampling, 1, 1)
+        self.jpeg_optimize = QCheckBox("Optimize")
+        self.jpeg_optimize.setChecked(JPEG_DEFAULTS["optimize"])
+        jpeg_grid.addWidget(self.jpeg_optimize, 2, 0, 1, 2)
+        jpeg_grid.addWidget(QLabel("Smooth:"), 3, 0)
+        self.jpeg_smooth = QSpinBox()
+        self.jpeg_smooth.setRange(0, 100)
+        self.jpeg_smooth.setValue(JPEG_DEFAULTS["smooth"])
+        jpeg_grid.addWidget(self.jpeg_smooth, 3, 1)
+        self.jpeg_keep_rgb = QCheckBox("Keep RGB")
+        self.jpeg_keep_rgb.setChecked(JPEG_DEFAULTS["keep_rgb"])
+        jpeg_grid.addWidget(self.jpeg_keep_rgb, 4, 0, 1, 2)
+        self.advanced_box.add_widget(jpeg_group)
+
+        # WebP settings
+        webp_group = QGroupBox("WebP")
+        webp_grid = QGridLayout(webp_group)
+        self.webp_lossless = QCheckBox("Lossless")
+        self.webp_lossless.setChecked(WEBP_DEFAULTS["lossless"])
+        webp_grid.addWidget(self.webp_lossless, 0, 0, 1, 2)
+        webp_grid.addWidget(QLabel("Method:"), 1, 0)
+        self.webp_method = QSpinBox()
+        self.webp_method.setRange(0, 6)
+        self.webp_method.setValue(WEBP_DEFAULTS["method"])
+        webp_grid.addWidget(self.webp_method, 1, 1)
+        webp_grid.addWidget(QLabel("Alpha quality:"), 2, 0)
+        self.webp_alpha_quality = QSpinBox()
+        self.webp_alpha_quality.setRange(0, 100)
+        self.webp_alpha_quality.setValue(WEBP_DEFAULTS["alpha_quality"])
+        webp_grid.addWidget(self.webp_alpha_quality, 2, 1)
+        self.webp_exact = QCheckBox("Exact alpha")
+        self.webp_exact.setChecked(WEBP_DEFAULTS["exact"])
+        webp_grid.addWidget(self.webp_exact, 3, 0, 1, 2)
+        self.advanced_box.add_widget(webp_group)
+
+        # AVIF settings
+        avif_group = QGroupBox("AVIF")
+        avif_grid = QGridLayout(avif_group)
+        avif_grid.addWidget(QLabel("Subsampling:"), 0, 0)
+        self.avif_subsampling = QComboBox()
+        self.avif_subsampling.addItems(["4:2:0", "4:2:2", "4:4:4"])
+        self.avif_subsampling.setCurrentText(AVIF_DEFAULTS["subsampling"])
+        avif_grid.addWidget(self.avif_subsampling, 0, 1)
+        avif_grid.addWidget(QLabel("Speed:"), 1, 0)
+        self.avif_speed = QSpinBox()
+        self.avif_speed.setRange(0, 10)
+        self.avif_speed.setValue(AVIF_DEFAULTS["speed"])
+        avif_grid.addWidget(self.avif_speed, 1, 1)
+        avif_grid.addWidget(QLabel("Codec:"), 2, 0)
+        self.avif_codec = QComboBox()
+        self.avif_codec.addItems(["auto", "aom", "rav1e", "svt"])
+        self.avif_codec.setCurrentText(AVIF_DEFAULTS["codec"])
+        avif_grid.addWidget(self.avif_codec, 2, 1)
+        avif_grid.addWidget(QLabel("Range:"), 3, 0)
+        self.avif_range = QComboBox()
+        self.avif_range.addItems(["full", "limited"])
+        self.avif_range.setCurrentText(AVIF_DEFAULTS["range"])
+        avif_grid.addWidget(self.avif_range, 3, 1)
+        avif_grid.addWidget(QLabel("Qmin:"), 4, 0)
+        self.avif_qmin = QSpinBox()
+        self.avif_qmin.setRange(-1, 63)
+        self.avif_qmin.setValue(AVIF_DEFAULTS["qmin"])
+        avif_grid.addWidget(self.avif_qmin, 4, 1)
+        avif_grid.addWidget(QLabel("Qmax:"), 5, 0)
+        self.avif_qmax = QSpinBox()
+        self.avif_qmax.setRange(-1, 63)
+        self.avif_qmax.setValue(AVIF_DEFAULTS["qmax"])
+        avif_grid.addWidget(self.avif_qmax, 5, 1)
+        self.avif_autotiling = QCheckBox("Autotiling")
+        self.avif_autotiling.setChecked(AVIF_DEFAULTS["autotiling"])
+        avif_grid.addWidget(self.avif_autotiling, 6, 0, 1, 2)
+        avif_grid.addWidget(QLabel("Tile rows:"), 7, 0)
+        self.avif_tile_rows = QSpinBox()
+        self.avif_tile_rows.setRange(0, 6)
+        self.avif_tile_rows.setValue(AVIF_DEFAULTS["tile_rows"])
+        avif_grid.addWidget(self.avif_tile_rows, 7, 1)
+        avif_grid.addWidget(QLabel("Tile cols:"), 8, 0)
+        self.avif_tile_cols = QSpinBox()
+        self.avif_tile_cols.setRange(0, 6)
+        self.avif_tile_cols.setValue(AVIF_DEFAULTS["tile_cols"])
+        avif_grid.addWidget(self.avif_tile_cols, 8, 1)
+        self.advanced_box.add_widget(avif_group)
+
+        layout.addWidget(self.advanced_box)
+
         # Conditions sub-panel
-        self.conditions_group = QGroupBox("Conditions")
-        cond_grid = QGridLayout(self.conditions_group)
+        self.conditions_box = CollapsibleBox("Conditions")
+        conditions_widget = QWidget()
+        cond_grid = QGridLayout(conditions_widget)
+        row = 0
 
         self.cond_smallest_cb = QCheckBox("Max smallest side:")
-        cond_grid.addWidget(self.cond_smallest_cb, 0, 0)
+        cond_grid.addWidget(self.cond_smallest_cb, row, 0)
         self.cond_smallest = QSpinBox()
         self.cond_smallest.setRange(1, 10000)
         self.cond_smallest.setEnabled(False)
-        cond_grid.addWidget(self.cond_smallest, 0, 1)
+        cond_grid.addWidget(self.cond_smallest, row, 1)
         self.cond_smallest_cb.stateChanged.connect(lambda s: self.cond_smallest.setEnabled(bool(s)))
+        row += 1
 
-        cond_grid.addWidget(QLabel("Orientation:"), 1, 0)
+        self.cond_largest_cb = QCheckBox("Max largest side:")
+        cond_grid.addWidget(self.cond_largest_cb, row, 0)
+        self.cond_largest = QSpinBox()
+        self.cond_largest.setRange(1, 10000)
+        self.cond_largest.setEnabled(False)
+        cond_grid.addWidget(self.cond_largest, row, 1)
+        self.cond_largest_cb.stateChanged.connect(lambda s: self.cond_largest.setEnabled(bool(s)))
+        row += 1
+
+        self.cond_pixels_cb = QCheckBox("Max pixels:")
+        cond_grid.addWidget(self.cond_pixels_cb, row, 0)
+        self.cond_pixels = QSpinBox()
+        self.cond_pixels.setRange(1, 1_000_000_000)
+        self.cond_pixels.setEnabled(False)
+        cond_grid.addWidget(self.cond_pixels, row, 1)
+        self.cond_pixels_cb.stateChanged.connect(lambda s: self.cond_pixels.setEnabled(bool(s)))
+        row += 1
+
+        self.cond_min_aspect_cb = QCheckBox("Min aspect ratio:")
+        cond_grid.addWidget(self.cond_min_aspect_cb, row, 0)
+        self.cond_min_aspect = QDoubleSpinBox()
+        self.cond_min_aspect.setRange(0.01, 100.0)
+        self.cond_min_aspect.setSingleStep(0.1)
+        self.cond_min_aspect.setEnabled(False)
+        cond_grid.addWidget(self.cond_min_aspect, row, 1)
+        self.cond_min_aspect_cb.stateChanged.connect(lambda s: self.cond_min_aspect.setEnabled(bool(s)))
+        row += 1
+
+        self.cond_max_aspect_cb = QCheckBox("Max aspect ratio:")
+        cond_grid.addWidget(self.cond_max_aspect_cb, row, 0)
+        self.cond_max_aspect = QDoubleSpinBox()
+        self.cond_max_aspect.setRange(0.01, 100.0)
+        self.cond_max_aspect.setSingleStep(0.1)
+        self.cond_max_aspect.setEnabled(False)
+        cond_grid.addWidget(self.cond_max_aspect, row, 1)
+        self.cond_max_aspect_cb.stateChanged.connect(lambda s: self.cond_max_aspect.setEnabled(bool(s)))
+        row += 1
+
+        cond_grid.addWidget(QLabel("Orientation:"), row, 0)
         self.orientation_combo = QComboBox()
         self.orientation_combo.addItems(["Any", "landscape", "portrait", "square"])
-        cond_grid.addWidget(self.orientation_combo, 1, 1)
+        cond_grid.addWidget(self.orientation_combo, row, 1)
+        row += 1
 
-        layout.addWidget(self.conditions_group)
+        cond_grid.addWidget(QLabel("Input formats:"), row, 0)
+        self.input_formats_edit = QLineEdit()
+        self.input_formats_edit.setPlaceholderText("jpg,png")
+        cond_grid.addWidget(self.input_formats_edit, row, 1)
+        row += 1
+
+        cond_grid.addWidget(QLabel("Transparency:"), row, 0)
+        self.transparency_combo = QComboBox()
+        self.transparency_combo.addItems(["Any", "Requires", "No"])
+        cond_grid.addWidget(self.transparency_combo, row, 1)
+        row += 1
+
+        self.cond_bytes_cb = QCheckBox("Max file size (bytes):")
+        cond_grid.addWidget(self.cond_bytes_cb, row, 0)
+        self.cond_bytes = QSpinBox()
+        self.cond_bytes.setRange(1, 1_000_000_000)
+        self.cond_bytes.setEnabled(False)
+        cond_grid.addWidget(self.cond_bytes, row, 1)
+        self.cond_bytes_cb.stateChanged.connect(lambda s: self.cond_bytes.setEnabled(bool(s)))
+        row += 1
+
+        cond_grid.addWidget(QLabel("Required EXIF (k=v,...):"), row, 0)
+        self.exif_edit = QLineEdit()
+        cond_grid.addWidget(self.exif_edit, row, 1)
+
+        self.conditions_box.add_widget(conditions_widget)
+        layout.addWidget(self.conditions_box)
+
+        if not self.allow_conditions:
+            self.conditions_box.toggle_button.setText("Conditions (default profile - always used)")
+            self.conditions_box.toggle_button.setEnabled(False)
+            self.conditions_box.content.setEnabled(False)
 
     # ------------------------------------------------------------------
     def get_parameters(self) -> dict[str, Any]:
@@ -108,13 +287,51 @@ class ProfilePanel(QWidget):
             "max_smallest_side": self.max_smallest.value() if self.max_smallest_cb.isChecked() else None,
             "preserve_structure": self.preserve_cb.isChecked(),
             "output_format": self.format_combo.currentText(),
+            "jpeg_params": {
+                "progressive": self.jpeg_progressive.isChecked(),
+                "subsampling": self.jpeg_subsampling.currentText(),
+                "optimize": self.jpeg_optimize.isChecked(),
+                "smooth": self.jpeg_smooth.value(),
+                "keep_rgb": self.jpeg_keep_rgb.isChecked(),
+            },
+            "webp_params": {
+                "lossless": self.webp_lossless.isChecked(),
+                "method": self.webp_method.value(),
+                "alpha_quality": self.webp_alpha_quality.value(),
+                "exact": self.webp_exact.isChecked(),
+            },
+            "avif_params": {
+                "subsampling": self.avif_subsampling.currentText(),
+                "speed": self.avif_speed.value(),
+                "codec": self.avif_codec.currentText(),
+                "range": self.avif_range.currentText(),
+                "qmin": self.avif_qmin.value(),
+                "qmax": self.avif_qmax.value(),
+                "autotiling": self.avif_autotiling.isChecked(),
+                "tile_rows": self.avif_tile_rows.value(),
+                "tile_cols": self.avif_tile_cols.value(),
+            },
         }
 
     def get_conditions(self) -> ProfileConditions:
         """Return matching conditions configured in the panel."""
+        if not self.allow_conditions:
+            return ProfileConditions()
         return ProfileConditions(
             max_input_smallest_side=self.cond_smallest.value() if self.cond_smallest_cb.isChecked() else None,
+            max_input_largest_side=self.cond_largest.value() if self.cond_largest_cb.isChecked() else None,
+            max_input_pixels=self.cond_pixels.value() if self.cond_pixels_cb.isChecked() else None,
+            min_aspect_ratio=self.cond_min_aspect.value() if self.cond_min_aspect_cb.isChecked() else None,
+            max_aspect_ratio=self.cond_max_aspect.value() if self.cond_max_aspect_cb.isChecked() else None,
             orientation=None if self.orientation_combo.currentText() == "Any" else self.orientation_combo.currentText(),
+            input_formats=[s.strip() for s in self.input_formats_edit.text().split(",") if s.strip()] or None,
+            requires_transparency={
+                "Any": None,
+                "Requires": True,
+                "No": False,
+            }[self.transparency_combo.currentText()],
+            max_input_bytes=self.cond_bytes.value() if self.cond_bytes_cb.isChecked() else None,
+            required_exif=dict(part.split("=", 1) for part in self.exif_edit.text().split(",") if "=" in part) or None,
         )
 
     def to_profile(self) -> CompressionProfile:
@@ -126,6 +343,9 @@ class ProfilePanel(QWidget):
             max_smallest_side=params["max_smallest_side"],
             output_format=params["output_format"],
             preserve_structure=params["preserve_structure"],
+            jpeg_params=params["jpeg_params"],
+            webp_params=params["webp_params"],
+            avif_params=params["avif_params"],
         )
         profile.conditions = self.get_conditions()
         return profile
@@ -151,6 +371,30 @@ class ProfilePanel(QWidget):
         self.format_combo.setCurrentText(profile.output_format)
         self.preserve_cb.setChecked(profile.preserve_structure)
 
+        jpeg = profile.jpeg_params
+        self.jpeg_progressive.setChecked(jpeg.get("progressive", JPEG_DEFAULTS["progressive"]))
+        self.jpeg_subsampling.setCurrentText(jpeg.get("subsampling", JPEG_DEFAULTS["subsampling"]))
+        self.jpeg_optimize.setChecked(jpeg.get("optimize", JPEG_DEFAULTS["optimize"]))
+        self.jpeg_smooth.setValue(jpeg.get("smooth", JPEG_DEFAULTS["smooth"]))
+        self.jpeg_keep_rgb.setChecked(jpeg.get("keep_rgb", JPEG_DEFAULTS["keep_rgb"]))
+
+        webp = profile.webp_params
+        self.webp_lossless.setChecked(webp.get("lossless", WEBP_DEFAULTS["lossless"]))
+        self.webp_method.setValue(webp.get("method", WEBP_DEFAULTS["method"]))
+        self.webp_alpha_quality.setValue(webp.get("alpha_quality", WEBP_DEFAULTS["alpha_quality"]))
+        self.webp_exact.setChecked(webp.get("exact", WEBP_DEFAULTS["exact"]))
+
+        avif = profile.avif_params
+        self.avif_subsampling.setCurrentText(avif.get("subsampling", AVIF_DEFAULTS["subsampling"]))
+        self.avif_speed.setValue(avif.get("speed", AVIF_DEFAULTS["speed"]))
+        self.avif_codec.setCurrentText(avif.get("codec", AVIF_DEFAULTS["codec"]))
+        self.avif_range.setCurrentText(avif.get("range", AVIF_DEFAULTS["range"]))
+        self.avif_qmin.setValue(avif.get("qmin", AVIF_DEFAULTS["qmin"]))
+        self.avif_qmax.setValue(avif.get("qmax", AVIF_DEFAULTS["qmax"]))
+        self.avif_autotiling.setChecked(avif.get("autotiling", AVIF_DEFAULTS["autotiling"]))
+        self.avif_tile_rows.setValue(avif.get("tile_rows", AVIF_DEFAULTS["tile_rows"]))
+        self.avif_tile_cols.setValue(avif.get("tile_cols", AVIF_DEFAULTS["tile_cols"]))
+
         cond = profile.conditions
         if cond.max_input_smallest_side is not None:
             self.cond_smallest_cb.setChecked(True)
@@ -159,10 +403,62 @@ class ProfilePanel(QWidget):
             self.cond_smallest_cb.setChecked(False)
             self.cond_smallest.setEnabled(False)
 
+        if cond.max_input_largest_side is not None:
+            self.cond_largest_cb.setChecked(True)
+            self.cond_largest.setValue(cond.max_input_largest_side)
+        else:
+            self.cond_largest_cb.setChecked(False)
+            self.cond_largest.setEnabled(False)
+
+        if cond.max_input_pixels is not None:
+            self.cond_pixels_cb.setChecked(True)
+            self.cond_pixels.setValue(cond.max_input_pixels)
+        else:
+            self.cond_pixels_cb.setChecked(False)
+            self.cond_pixels.setEnabled(False)
+
+        if cond.min_aspect_ratio is not None:
+            self.cond_min_aspect_cb.setChecked(True)
+            self.cond_min_aspect.setValue(cond.min_aspect_ratio)
+        else:
+            self.cond_min_aspect_cb.setChecked(False)
+            self.cond_min_aspect.setEnabled(False)
+
+        if cond.max_aspect_ratio is not None:
+            self.cond_max_aspect_cb.setChecked(True)
+            self.cond_max_aspect.setValue(cond.max_aspect_ratio)
+        else:
+            self.cond_max_aspect_cb.setChecked(False)
+            self.cond_max_aspect.setEnabled(False)
+
         if cond.orientation:
             self.orientation_combo.setCurrentText(cond.orientation)
         else:
             self.orientation_combo.setCurrentText("Any")
+
+        if cond.input_formats:
+            self.input_formats_edit.setText(",".join(cond.input_formats))
+        else:
+            self.input_formats_edit.clear()
+
+        if cond.requires_transparency is True:
+            self.transparency_combo.setCurrentText("Requires")
+        elif cond.requires_transparency is False:
+            self.transparency_combo.setCurrentText("No")
+        else:
+            self.transparency_combo.setCurrentText("Any")
+
+        if cond.max_input_bytes is not None:
+            self.cond_bytes_cb.setChecked(True)
+            self.cond_bytes.setValue(cond.max_input_bytes)
+        else:
+            self.cond_bytes_cb.setChecked(False)
+            self.cond_bytes.setEnabled(False)
+
+        if cond.required_exif:
+            self.exif_edit.setText(",".join(f"{k}={v}" for k, v in cond.required_exif.items()))
+        else:
+            self.exif_edit.clear()
 
     def reset_to_defaults(self) -> None:
         self.name_edit.clear()
@@ -179,6 +475,40 @@ class ProfilePanel(QWidget):
         self.format_combo.setCurrentText(BASIC_DEFAULTS["output_format"])
         self.preserve_cb.setChecked(BASIC_DEFAULTS["preserve_structure"])
 
+        self.jpeg_progressive.setChecked(JPEG_DEFAULTS["progressive"])
+        self.jpeg_subsampling.setCurrentText(JPEG_DEFAULTS["subsampling"])
+        self.jpeg_optimize.setChecked(JPEG_DEFAULTS["optimize"])
+        self.jpeg_smooth.setValue(JPEG_DEFAULTS["smooth"])
+        self.jpeg_keep_rgb.setChecked(JPEG_DEFAULTS["keep_rgb"])
+
+        self.webp_lossless.setChecked(WEBP_DEFAULTS["lossless"])
+        self.webp_method.setValue(WEBP_DEFAULTS["method"])
+        self.webp_alpha_quality.setValue(WEBP_DEFAULTS["alpha_quality"])
+        self.webp_exact.setChecked(WEBP_DEFAULTS["exact"])
+
+        self.avif_subsampling.setCurrentText(AVIF_DEFAULTS["subsampling"])
+        self.avif_speed.setValue(AVIF_DEFAULTS["speed"])
+        self.avif_codec.setCurrentText(AVIF_DEFAULTS["codec"])
+        self.avif_range.setCurrentText(AVIF_DEFAULTS["range"])
+        self.avif_qmin.setValue(AVIF_DEFAULTS["qmin"])
+        self.avif_qmax.setValue(AVIF_DEFAULTS["qmax"])
+        self.avif_autotiling.setChecked(AVIF_DEFAULTS["autotiling"])
+        self.avif_tile_rows.setValue(AVIF_DEFAULTS["tile_rows"])
+        self.avif_tile_cols.setValue(AVIF_DEFAULTS["tile_cols"])
+
         self.cond_smallest_cb.setChecked(False)
         self.cond_smallest.setEnabled(False)
+        self.cond_largest_cb.setChecked(False)
+        self.cond_largest.setEnabled(False)
+        self.cond_pixels_cb.setChecked(False)
+        self.cond_pixels.setEnabled(False)
+        self.cond_min_aspect_cb.setChecked(False)
+        self.cond_min_aspect.setEnabled(False)
+        self.cond_max_aspect_cb.setChecked(False)
+        self.cond_max_aspect.setEnabled(False)
         self.orientation_combo.setCurrentText("Any")
+        self.input_formats_edit.clear()
+        self.transparency_combo.setCurrentText("Any")
+        self.cond_bytes_cb.setChecked(False)
+        self.cond_bytes.setEnabled(False)
+        self.exif_edit.clear()

--- a/service/profile_panel.py
+++ b/service/profile_panel.py
@@ -92,8 +92,8 @@ class ProfilePanel(QWidget):
         self.advanced_box = CollapsibleBox("Advanced Settings")
 
         # JPEG settings
-        jpeg_group = QGroupBox("JPEG")
-        jpeg_grid = QGridLayout(jpeg_group)
+        self.jpeg_group = QGroupBox("JPEG")
+        jpeg_grid = QGridLayout(self.jpeg_group)
         self.jpeg_progressive = QCheckBox("Progressive")
         self.jpeg_progressive.setChecked(JPEG_DEFAULTS["progressive"])
         jpeg_grid.addWidget(self.jpeg_progressive, 0, 0, 1, 2)
@@ -113,11 +113,11 @@ class ProfilePanel(QWidget):
         self.jpeg_keep_rgb = QCheckBox("Keep RGB")
         self.jpeg_keep_rgb.setChecked(JPEG_DEFAULTS["keep_rgb"])
         jpeg_grid.addWidget(self.jpeg_keep_rgb, 4, 0, 1, 2)
-        self.advanced_box.add_widget(jpeg_group)
+        self.advanced_box.add_widget(self.jpeg_group)
 
         # WebP settings
-        webp_group = QGroupBox("WebP")
-        webp_grid = QGridLayout(webp_group)
+        self.webp_group = QGroupBox("WebP")
+        webp_grid = QGridLayout(self.webp_group)
         self.webp_lossless = QCheckBox("Lossless")
         self.webp_lossless.setChecked(WEBP_DEFAULTS["lossless"])
         webp_grid.addWidget(self.webp_lossless, 0, 0, 1, 2)
@@ -134,11 +134,11 @@ class ProfilePanel(QWidget):
         self.webp_exact = QCheckBox("Exact alpha")
         self.webp_exact.setChecked(WEBP_DEFAULTS["exact"])
         webp_grid.addWidget(self.webp_exact, 3, 0, 1, 2)
-        self.advanced_box.add_widget(webp_group)
+        self.advanced_box.add_widget(self.webp_group)
 
         # AVIF settings
-        avif_group = QGroupBox("AVIF")
-        avif_grid = QGridLayout(avif_group)
+        self.avif_group = QGroupBox("AVIF")
+        avif_grid = QGridLayout(self.avif_group)
         avif_grid.addWidget(QLabel("Subsampling:"), 0, 0)
         self.avif_subsampling = QComboBox()
         self.avif_subsampling.addItems(["4:2:0", "4:2:2", "4:4:4"])
@@ -182,9 +182,12 @@ class ProfilePanel(QWidget):
         self.avif_tile_cols.setRange(0, 6)
         self.avif_tile_cols.setValue(AVIF_DEFAULTS["tile_cols"])
         avif_grid.addWidget(self.avif_tile_cols, 8, 1)
-        self.advanced_box.add_widget(avif_group)
+        self.advanced_box.add_widget(self.avif_group)
 
         layout.addWidget(self.advanced_box)
+
+        self.format_combo.currentTextChanged.connect(self._update_advanced_visibility)
+        self._update_advanced_visibility(self.format_combo.currentText())
 
         # Conditions sub-panel
         self.conditions_box = CollapsibleBox("Conditions")
@@ -277,6 +280,11 @@ class ProfilePanel(QWidget):
             self.conditions_box.toggle_button.setText("Conditions (default profile - always used)")
             self.conditions_box.toggle_button.setEnabled(False)
             self.conditions_box.content.setEnabled(False)
+
+    def _update_advanced_visibility(self, fmt: str) -> None:
+        self.jpeg_group.setVisible(fmt == "JPEG")
+        self.webp_group.setVisible(fmt == "WEBP")
+        self.avif_group.setVisible(fmt == "AVIF")
 
     # ------------------------------------------------------------------
     def get_parameters(self) -> dict[str, Any]:

--- a/tests/test_output_directory.py
+++ b/tests/test_output_directory.py
@@ -1,0 +1,46 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from PySide6.QtWidgets import QApplication
+
+from service.image_compression import ImageCompressor
+from service.main import MainWindow
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_process_directory_rejects_existing(tmp_path: Path) -> None:
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    Image.new("RGB", (10, 10)).save(input_dir / "a.jpg")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    compressor = ImageCompressor()
+    with pytest.raises(FileExistsError):
+        compressor.process_directory(input_dir, output_dir)
+
+
+def test_regenerate_output_directory_button(qapp: QApplication, tmp_path: Path) -> None:
+    window = MainWindow()
+    qapp.processEvents()
+    window.input_directory = tmp_path / "in"
+    window.input_directory.mkdir()
+    window.regenerate_output_directory()
+    first = window.output_directory
+    assert first is not None
+    first.mkdir()
+    window.regen_output_btn.click()
+    qapp.processEvents()
+    assert window.output_directory != first
+    assert not window.output_directory.exists()

--- a/tests/test_profile_application.py
+++ b/tests/test_profile_application.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from PIL import Image
+
+from service.compression_profiles import CompressionProfile, NumericCondition, ProfileConditions
+from service.image_compression import ImageCompressor
+
+
+def test_process_directory_uses_profiles(tmp_path: Path) -> None:
+    small_img = tmp_path / "small.jpg"
+    large_img = tmp_path / "large.jpg"
+    Image.new("RGB", (500, 500), color="red").save(small_img)
+    Image.new("RGB", (2000, 2000), color="blue").save(large_img)
+
+    default = CompressionProfile(name="Default")
+    small_profile = CompressionProfile(
+        name="Small",
+        output_format="WEBP",
+        conditions=ProfileConditions(
+            smallest_side=NumericCondition("<", 1000),
+        ),
+    )
+    profiles = [default, small_profile]
+
+    compressor = ImageCompressor()
+    output_dir = tmp_path / "out"
+    compressor.process_directory(tmp_path, output_dir, profiles)
+
+    assert (output_dir / "small.webp").exists()
+    assert (output_dir / "large.jpg").exists()

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1,0 +1,37 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from service.main import MainWindow
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_remove_and_reset_profiles(qapp: QApplication) -> None:
+    window = MainWindow()
+    qapp.processEvents()
+
+    assert len(window.profile_panels) == 1
+    assert window.profile_panels[0].title == "Default"
+
+    window.add_profile_panel()
+    qapp.processEvents()
+    assert len(window.profile_panels) == 2
+
+    window.profile_panels[1].remove_btn.click()
+    qapp.processEvents()
+    assert len(window.profile_panels) == 1
+
+    window.reset_settings()
+    qapp.processEvents()
+    assert len(window.profile_panels) == 1
+    assert window.profile_panels[0].title == "Default"

--- a/tests/test_profile_panel_visibility.py
+++ b/tests/test_profile_panel_visibility.py
@@ -1,0 +1,38 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from service.profile_panel import ProfilePanel
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_advanced_settings_visibility(qapp: QApplication) -> None:
+    assert qapp is not None  # ensure fixture is used
+    panel = ProfilePanel("Test")
+    panel.show()
+    qapp.processEvents()
+    panel.advanced_box.toggle_button.click()  # expand to check visibility
+
+    assert panel.jpeg_group.isVisible()
+    assert not panel.webp_group.isVisible()
+    assert not panel.avif_group.isVisible()
+
+    panel.format_combo.setCurrentText("WEBP")
+    assert not panel.jpeg_group.isVisible()
+    assert panel.webp_group.isVisible()
+    assert not panel.avif_group.isVisible()
+
+    panel.format_combo.setCurrentText("AVIF")
+    assert not panel.jpeg_group.isVisible()
+    assert not panel.webp_group.isVisible()
+    assert panel.avif_group.isVisible()

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from PIL import Image
+
+from service.compression_profiles import (
+    CompressionProfile,
+    ProfileConditions,
+    load_profiles,
+    save_profiles,
+    select_profile,
+)
+
+
+def test_profile_save_load_and_selection(tmp_path: Path) -> None:
+    profiles = [
+        CompressionProfile(
+            name="small",
+            quality=90,
+            conditions=ProfileConditions(max_input_smallest_side=1080),
+        ),
+        CompressionProfile(name="default", quality=75),
+    ]
+    file_path = tmp_path / "profiles.json"
+    save_profiles(profiles, file_path)
+    loaded = load_profiles(file_path)
+
+    assert [p.name for p in loaded] == ["small", "default"]
+
+    small_image = tmp_path / "small.jpg"
+    Image.new("RGB", (800, 600)).save(small_image)
+    profile = select_profile(small_image, loaded)
+    assert profile is not None
+    assert profile.name == "small"
+
+    large_image = tmp_path / "large.jpg"
+    Image.new("RGB", (2000, 1500)).save(large_image)
+    profile = select_profile(large_image, loaded)
+    assert profile is not None
+    assert profile.name == "default"
+
+
+def test_profile_orientation_and_format(tmp_path: Path) -> None:
+    profiles = [
+        CompressionProfile(
+            name="portrait_png",
+            conditions=ProfileConditions(
+                orientation="portrait",
+                input_formats=["PNG"],
+                requires_transparency=True,
+            ),
+        ),
+        CompressionProfile(name="default"),
+    ]
+
+    portrait = tmp_path / "portrait.png"
+    Image.new("RGBA", (600, 800)).save(portrait)
+
+    profile = select_profile(portrait, profiles)
+    assert profile is not None
+    assert profile.name == "portrait_png"
+
+    landscape = tmp_path / "land.jpg"
+    Image.new("RGB", (800, 600)).save(landscape)
+    profile = select_profile(landscape, profiles)
+    assert profile is not None
+    assert profile.name == "default"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -4,6 +4,7 @@ from PIL import Image
 
 from service.compression_profiles import (
     CompressionProfile,
+    NumericCondition,
     ProfileConditions,
     load_profiles,
     save_profiles,
@@ -16,7 +17,7 @@ def test_profile_save_load_and_selection(tmp_path: Path) -> None:
         CompressionProfile(
             name="small",
             quality=90,
-            conditions=ProfileConditions(max_input_smallest_side=1080),
+            conditions=ProfileConditions(smallest_side=NumericCondition(op="<=", value=1080)),
         ),
         CompressionProfile(name="default", quality=75),
     ]


### PR DESCRIPTION
## Summary
- support additional profile conditions like aspect ratio, orientation, file size, and format
- add Profiles menu to save and load compression profiles from the main window
- test orientation and format matching for profile selection

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest`
- `make pre-commit-all`


------
https://chatgpt.com/codex/tasks/task_e_68b1ced793a48332a12e241660e28fa5