### PR TITLE
[photo_compresser] Add configurable parallel image compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - Выбор формата вывода (JPEG, WebP, AVIF)
 - **Сохранение структуры папок**: Опция для сохранения или уплощения структуры папок
 - **Поддержка форматов**: JPEG, PNG, BMP, TIFF, WebP
+- **Параллельная обработка**: Настраиваемое количество потоков для ускорения сжатия
 - **Статистика сжатия**: Показывает размер до/после, процент сжатия, экономию места
 
 ### Сравнение изображений
@@ -58,6 +59,15 @@ python main.py
      - ❌ Выключено: Все файлы помещаются в одну папку (например, `Photos/Vacation/IMG_001.jpg` → `Photos_compressed/IMG_001.jpg`)
 3. **Запуск сжатия**: Нажмите "Start Compression"
 4. **Просмотр результатов**: После завершения нажмите "Compare Images"
+
+### Использование в коде
+
+```python
+from service.image_compression import ImageCompressor
+
+compressor = ImageCompressor(num_workers=4)
+compressor.process_directory(input_path, output_path, num_workers=4)
+```
 
 ### Сравнение изображений
 

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from PIL import Image
+
+from service.image_compression import ImageCompressor
+
+
+def test_process_directory_parallel(tmp_path: Path) -> None:
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    for i in range(3):
+        Image.new("RGB", (10, 10)).save(input_dir / f"img{i}.jpg")
+    output_dir = tmp_path / "out"
+    compressor = ImageCompressor()
+    total, compressed, _, failed = compressor.process_directory(input_dir, output_dir, num_workers=2)
+    assert total == 3
+    assert compressed == 3
+    assert failed == []


### PR DESCRIPTION
## Summary
- enable threaded image compression with configurable worker count
- document and test parallel processing

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest`
- `make pre-commit-all`


------
https://chatgpt.com/codex/tasks/task_e_68b21cc58b5c8332952e49ada5c7afef