### PR TITLE
[photo_compresser] Add video compression support

### DIFF
--- a/service/constants.py
+++ b/service/constants.py
@@ -15,3 +15,11 @@ SUPPORTED_EXTENSIONS = {
     ".pgm",
     ".pbm",
 }
+
+VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".mkv",
+    ".mov",
+    ".avi",
+    ".webm",
+}

--- a/service/parameters_defaults.py
+++ b/service/parameters_defaults.py
@@ -39,6 +39,14 @@ class AvifDefaults(TypedDict):
     tile_cols: int
 
 
+class VideoDefaults(TypedDict):
+    bitrate: int
+    max_width: int
+    max_height: int
+    output_format: str
+    codec: str
+
+
 BASIC_DEFAULTS: BasicDefaults = {
     "quality": 75,
     "max_largest_enabled": False,
@@ -84,4 +92,12 @@ AVIF_DEFAULTS: AvifDefaults = {
     "autotiling": True,
     "tile_rows": 0,
     "tile_cols": 0,
+}
+
+VIDEO_DEFAULTS: VideoDefaults = {
+    "bitrate": 1000,
+    "max_width": 1920,
+    "max_height": 1080,
+    "output_format": "mp4",
+    "codec": "libx264",
 }

--- a/service/profile_panel.py
+++ b/service/profile_panel.py
@@ -107,7 +107,7 @@ class ProfilePanel(QWidget):
 
         # Profile name and remove button
         name_layout = QHBoxLayout()
-        self.name_label = QLabel(tr("Name") + ":")
+        self.name_label = QLabel("🖼️ " + tr("Name") + ":")
         name_layout.addWidget(self.name_label)
         self.name_edit = QLineEdit()
         self.name_edit.setPlaceholderText(self.title)

--- a/service/video_compression.py
+++ b/service/video_compression.py
@@ -1,0 +1,149 @@
+"""Video compression utilities using ffmpeg."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from threading import Event
+from typing import Any, Callable, Sequence
+
+from service.compression_profiles import (
+    VideoCompressionProfile,
+    select_video_profile,
+)
+from service.constants import VIDEO_EXTENSIONS
+from service.file_utils import copy_times_from_src
+from service.translator import tr
+
+logger = logging.getLogger(__name__)
+
+
+class VideoCompressor:
+    """Simple video compressor based on ffmpeg."""
+
+    def __init__(
+        self,
+        bitrate: str | None = "1000k",
+        max_width: int | None = None,
+        max_height: int | None = None,
+        output_format: str = "mp4",
+        *,
+        preserve_structure: bool = True,
+        copy_unsupported: bool = True,
+    ) -> None:
+        self.bitrate = bitrate
+        self.max_width = max_width
+        self.max_height = max_height
+        self.output_format = output_format
+        self.preserve_structure = preserve_structure
+        self.copy_unsupported = copy_unsupported
+        self.codec = "libx264"
+        self.advanced_params: dict[str, Any] = {}
+
+    def apply_profile(self, profile: VideoCompressionProfile) -> None:
+        self.bitrate = profile.bitrate
+        self.max_width = profile.max_width
+        self.max_height = profile.max_height
+        self.output_format = profile.output_format
+        self.codec = profile.codec
+        self.advanced_params = profile.advanced_params
+
+    def set_advanced_parameters(self, **kwargs: Any) -> None:
+        self.advanced_params = kwargs
+
+    def compress_video(self, input_path: Path, output_path: Path) -> Path | None:
+        cmd = ["ffmpeg", "-y", "-i", str(input_path)]
+        if self.bitrate:
+            cmd += ["-b:v", str(self.bitrate)]
+        cmd += ["-c:v", self.codec]
+        for k, v in self.advanced_params.items():
+            cmd += [str(k), str(v)]
+        cmd.append(str(output_path))
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
+            copy_times_from_src(input_path, output_path)
+            logger.info("Compressed video %s", input_path.name)
+            return output_path
+        except Exception as exc:  # pragma: no cover - log and skip
+            logger.error("Failed to compress %s: %s", input_path, exc)
+            return None
+
+    def process_directory(
+        self,
+        input_root: Path,
+        output_root: Path,
+        profiles: Sequence[VideoCompressionProfile] | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+        status_callback: Callable[[str], None] | None = None,
+        log_callback: Callable[[str], None] | None = None,
+        stop_event: Event | None = None,
+    ) -> tuple[int, int, list[Path], list[Path]]:
+        """Process directory and compress supported video files."""
+
+        total_files = sum(1 for f in input_root.rglob("*") if f.is_file() and f.suffix.lower() in VIDEO_EXTENSIONS)
+        if not profiles or total_files == 0:
+            return (0, 0, [], [])
+
+        processed = 0
+        compressed = 0
+        compressed_paths: list[Path] = []
+        failed: list[Path] = []
+
+        for file_path in input_root.rglob("*"):
+            if stop_event and stop_event.is_set():
+                break
+            if not file_path.is_file():
+                continue
+            if file_path.suffix.lower() not in VIDEO_EXTENSIONS:
+                if self.copy_unsupported:
+                    if self.preserve_structure:
+                        rel = file_path.relative_to(input_root)
+                        out_file = output_root / rel
+                    else:
+                        out_file = output_root / file_path.name
+                    out_file.parent.mkdir(parents=True, exist_ok=True)
+                    out_file.write_bytes(file_path.read_bytes())
+                    copy_times_from_src(file_path, out_file)
+                continue
+
+            profile = select_video_profile(file_path, profiles) if profiles else None
+            comp = VideoCompressor(
+                bitrate=self.bitrate,
+                max_width=self.max_width,
+                max_height=self.max_height,
+                output_format=self.output_format,
+                preserve_structure=self.preserve_structure,
+                copy_unsupported=self.copy_unsupported,
+            )
+            if profile:
+                comp.apply_profile(profile)
+
+            if comp.preserve_structure:
+                rel = file_path.relative_to(input_root)
+                out_file = output_root / rel
+                out_file = out_file.with_suffix(f".{comp.output_format}")
+            else:
+                out_file = output_root / f"{file_path.stem}.{comp.output_format}"
+
+            out_file.parent.mkdir(parents=True, exist_ok=True)
+            saved = comp.compress_video(file_path, out_file)
+            profile_name = profile.name if profile else tr("Default")
+            if saved:
+                compressed += 1
+                compressed_paths.append(saved)
+                msg = tr("Compressed video: {name} with profile {profile}").format(
+                    name=file_path.name, profile=profile_name
+                )
+            else:
+                failed.append(file_path)
+                msg = tr("Failed to compress video: {name}").format(name=file_path.name)
+            if log_callback:
+                log_callback(msg)
+            processed += 1
+            if progress_callback:
+                progress_callback(processed, total_files)
+            if status_callback:
+                status_callback(msg)
+
+        return (total_files, compressed, compressed_paths, failed)

--- a/service/video_profile_panel.py
+++ b/service/video_profile_panel.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import contextlib
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QSpinBox,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from service.compression_profiles import (
+    NumericCondition,
+    VideoCompressionProfile,
+    VideoProfileConditions,
+)
+from service.translator import tr
+
+
+class VideoProfilePanel(QWidget):
+    """Panel for configuring video compression profiles."""
+
+    remove_requested = Signal()
+
+    def __init__(
+        self,
+        title: str,
+        *,
+        allow_conditions: bool = True,
+        removable: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.title = title
+        self.allow_conditions = allow_conditions
+        self.removable = removable
+        self._build_ui()
+        self.update_translations()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        name_layout = QHBoxLayout()
+        self.name_label = QLabel("🎬 " + tr("Name") + ":")
+        name_layout.addWidget(self.name_label)
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText(self.title)
+        name_layout.addWidget(self.name_edit)
+        name_layout.addStretch()
+        if self.removable:
+            remove_btn = QToolButton()
+            remove_btn.setText("✕")
+            remove_btn.setFixedSize(16, 16)
+            remove_btn.clicked.connect(self.remove_requested.emit)
+            name_layout.addWidget(remove_btn)
+            self.remove_btn = remove_btn
+        layout.addLayout(name_layout)
+
+        # Basic settings
+        self.basic_group = QGroupBox(tr("Compression Settings"))
+        grid = QGridLayout(self.basic_group)
+
+        self.bitrate_label = QLabel(tr("Bitrate (kbps)") + ":")
+        grid.addWidget(self.bitrate_label, 0, 0)
+        self.bitrate = QSpinBox()
+        self.bitrate.setRange(100, 100000)
+        self.bitrate.setValue(1000)
+        grid.addWidget(self.bitrate, 0, 1)
+
+        self.max_width_label = QLabel(tr("Max width") + ":")
+        grid.addWidget(self.max_width_label, 1, 0)
+        self.max_width = QSpinBox()
+        self.max_width.setRange(1, 10000)
+        self.max_width.setValue(1920)
+        grid.addWidget(self.max_width, 1, 1)
+
+        self.max_height_label = QLabel(tr("Max height") + ":")
+        grid.addWidget(self.max_height_label, 2, 0)
+        self.max_height = QSpinBox()
+        self.max_height.setRange(1, 10000)
+        self.max_height.setValue(1080)
+        grid.addWidget(self.max_height, 2, 1)
+
+        self.format_label = QLabel(tr("Format") + ":")
+        grid.addWidget(self.format_label, 3, 0)
+        self.format_combo = QComboBox()
+        self.format_combo.addItems(["mp4", "mkv", "webm"])
+        grid.addWidget(self.format_combo, 3, 1)
+
+        layout.addWidget(self.basic_group)
+
+        # Advanced settings
+        self.adv_group = QGroupBox(tr("Advanced Settings"))
+        adv_grid = QGridLayout(self.adv_group)
+
+        self.codec_label = QLabel(tr("Codec") + ":")
+        adv_grid.addWidget(self.codec_label, 0, 0)
+        self.codec_combo = QComboBox()
+        self.codec_combo.addItems(["libx264", "libx265", "libvpx-vp9"])
+        adv_grid.addWidget(self.codec_combo, 0, 1)
+
+        layout.addWidget(self.adv_group)
+
+        # Conditions
+        if self.allow_conditions:
+            self.cond_group = QGroupBox(tr("Conditions"))
+            cond_grid = QGridLayout(self.cond_group)
+
+            self.cond_width_cb = QCheckBox(tr("Width") + ":")
+            cond_grid.addWidget(self.cond_width_cb, 0, 0)
+            self.cond_width_op = QComboBox()
+            self.cond_width_op.addItems(["<=", "<", ">=", ">", "=="])
+            self.cond_width_op.setEnabled(False)
+            cond_grid.addWidget(self.cond_width_op, 0, 1)
+            self.cond_width = QSpinBox()
+            self.cond_width.setRange(1, 10000)
+            self.cond_width.setEnabled(False)
+            cond_grid.addWidget(self.cond_width, 0, 2)
+            self.cond_width_cb.stateChanged.connect(
+                lambda s: self._toggle_widgets(s, self.cond_width, self.cond_width_op)
+            )
+
+            self.cond_height_cb = QCheckBox(tr("Height") + ":")
+            cond_grid.addWidget(self.cond_height_cb, 1, 0)
+            self.cond_height_op = QComboBox()
+            self.cond_height_op.addItems(["<=", "<", ">=", ">", "=="])
+            self.cond_height_op.setEnabled(False)
+            cond_grid.addWidget(self.cond_height_op, 1, 1)
+            self.cond_height = QSpinBox()
+            self.cond_height.setRange(1, 10000)
+            self.cond_height.setEnabled(False)
+            cond_grid.addWidget(self.cond_height, 1, 2)
+            self.cond_height_cb.stateChanged.connect(
+                lambda s: self._toggle_widgets(s, self.cond_height, self.cond_height_op)
+            )
+
+            layout.addWidget(self.cond_group)
+
+        self.setStyleSheet("background-color: #e0f7fa;")
+
+    def _toggle_widgets(self, state: int, *widgets: QWidget) -> None:
+        enabled = state != 0
+        for w in widgets:
+            w.setEnabled(enabled)
+
+    def to_profile(self) -> VideoCompressionProfile:
+        conditions = VideoProfileConditions()
+        if self.allow_conditions:
+            if self.cond_width_cb.isChecked():
+                conditions.width = NumericCondition(self.cond_width_op.currentText(), float(self.cond_width.value()))
+            if self.cond_height_cb.isChecked():
+                conditions.height = NumericCondition(self.cond_height_op.currentText(), float(self.cond_height.value()))
+        return VideoCompressionProfile(
+            name=self.name_edit.text() or self.title,
+            bitrate=f"{self.bitrate.value()}k",
+            max_width=self.max_width.value(),
+            max_height=self.max_height.value(),
+            output_format=self.format_combo.currentText(),
+            codec=self.codec_combo.currentText(),
+            conditions=conditions,
+        )
+
+    def apply_profile(self, profile: VideoCompressionProfile) -> None:
+        self.name_edit.setText(profile.name)
+        if profile.bitrate:
+            with contextlib.suppress(ValueError):
+                self.bitrate.setValue(int(str(profile.bitrate).replace("k", "")))
+        if profile.max_width:
+            self.max_width.setValue(profile.max_width)
+        if profile.max_height:
+            self.max_height.setValue(profile.max_height)
+        self.format_combo.setCurrentText(profile.output_format)
+        self.codec_combo.setCurrentText(profile.codec)
+        if self.allow_conditions:
+            if profile.conditions.width:
+                self.cond_width_cb.setChecked(True)
+                self.cond_width_op.setCurrentText(profile.conditions.width.op)
+                self.cond_width.setValue(int(profile.conditions.width.value))
+            if profile.conditions.height:
+                self.cond_height_cb.setChecked(True)
+                self.cond_height_op.setCurrentText(profile.conditions.height.op)
+                self.cond_height.setValue(int(profile.conditions.height.value))
+
+    def update_translations(self) -> None:
+        self.basic_group.setTitle(tr("Compression Settings"))
+        self.adv_group.setTitle(tr("Advanced Settings"))
+        if self.allow_conditions:
+            self.cond_group.setTitle(tr("Conditions"))

--- a/tests/test_video_profile_management.py
+++ b/tests/test_video_profile_management.py
@@ -1,0 +1,37 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from service.main import MainWindow
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_video_profile_panels(qapp: QApplication) -> None:
+    window = MainWindow()
+    qapp.processEvents()
+
+    assert len(window.video_profile_panels) == 1
+    assert window.video_profile_panels[0].title == "Default Video"
+
+    window.add_video_profile_panel()
+    qapp.processEvents()
+    assert len(window.video_profile_panels) == 2
+
+    window.video_profile_panels[1].remove_btn.click()
+    qapp.processEvents()
+    assert len(window.video_profile_panels) == 1
+
+    window.reset_settings()
+    qapp.processEvents()
+    assert len(window.video_profile_panels) == 1
+    assert window.video_profile_panels[0].title == "Default Video"


### PR DESCRIPTION
## Summary
- add video compression profiles with ffmpeg backend
- separate video profile panels and processing logic
- include tests for managing video profiles

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2c923cfcc83328894727abc3d4c7d