### PR TITLE
[photo_compresser] Track compression profiles in output and preview

### DIFF
--- a/service/image_pair.py
+++ b/service/image_pair.py
@@ -93,10 +93,13 @@ class ImagePair:
     image1_path: str
     image2_path: str
     name: str = ""
+    profile: str = "Raw"
 
     def __post_init__(self) -> None:  # pragma: no cover - simple post-init
         if not self.name:
             self.name = f"{os.path.basename(self.image1_path)} vs {os.path.basename(self.image2_path)}"
+        if not self.profile:
+            self.profile = "Raw"
 
     def get_pixmap1(self) -> QPixmap:
         """Get the first image pixmap using the cache."""

--- a/service/main.py
+++ b/service/main.py
@@ -112,7 +112,9 @@ class CompressionWorker(QThread):
 
             # Create image pairs for settings file
             self.status_updated.emit(tr("Generating image pairs..."))
-            image_pairs = create_image_pairs(self.output_dir, self.input_dir)
+            raw_pairs = create_image_pairs(self.output_dir, self.input_dir)
+            profile_map = self.compressor.last_profile_map
+            image_pairs = [(orig, comp, profile_map.get(comp, tr("Raw"))) for orig, comp in raw_pairs]
             self.status_updated.emit(tr("Saving compression settings..."))
 
             # Save compression settings

--- a/service/translator.py
+++ b/service/translator.py
@@ -91,6 +91,8 @@ _translations: dict[str, dict[str, str]] = {
         "Select Second Directory": "Выберите вторую папку",
         "Showing: {name} ({index}/{total})": "Показ: {name} ({index}/{total})",
         "Loaded {count} image pairs": "Загружено {count} пар изображений",
+        "Profile: {profile}": "Профиль: {profile}",
+        "Raw": "Оригинальное фото",
         "Compression Statistics": "Статистика сжатия",
         "Metric": "Метрика",
         "Directory 1": "Папка 1",

--- a/tests/test_profile_in_settings.py
+++ b/tests/test_profile_in_settings.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from PIL import Image
+
+from service.compression_profiles import CompressionProfile
+from service.image_compression import (
+    ImageCompressor,
+    create_image_pairs,
+    save_compression_settings,
+)
+
+
+def test_profile_saved_in_settings(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    Image.new("RGB", (100, 100), color="red").save(input_dir / "img.jpg")
+
+    compressor = ImageCompressor()
+    default_profile = CompressionProfile(name="Default")
+    compressor.process_directory(input_dir, output_dir, [default_profile])
+
+    raw_pairs = create_image_pairs(output_dir, input_dir)
+    profile_map = compressor.last_profile_map
+    image_pairs = [(orig, comp, profile_map.get(comp, "Raw")) for orig, comp in raw_pairs]
+    save_compression_settings(output_dir, {}, image_pairs, {})
+
+    settings_file = output_dir / "compression_settings.json"
+    with settings_file.open() as f:
+        data = json.load(f)
+    assert data["image_pairs"][0]["profile"] == "Default"


### PR DESCRIPTION
## Summary
- record which profile compresses each image and write it to `compression_settings.json`
- show the used profile in preview window, defaulting to `Raw` when none
- add regression test for profile metadata

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest`
- `make pre-commit-all`


------
https://chatgpt.com/codex/tasks/task_e_68b2e68ba670833285b8f2954148bd1e