### PR TITLE
[photo_compresser] Add Adobe Media Encoder video support

### DIFF
--- a/service/constants.py
+++ b/service/constants.py
@@ -15,3 +15,14 @@ SUPPORTED_EXTENSIONS = {
     ".pgm",
     ".pbm",
 }
+
+SUPPORTED_VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".mkv",
+    ".webm",
+    ".mpg",
+    ".mpeg",
+    ".m4v",
+}

--- a/service/video_encoding.py
+++ b/service/video_encoding.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Video conversion helpers using Adobe Media Encoder."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+AME_COMMAND = "Adobe Media Encoder"
+
+
+def enqueue_videos(
+    videos: Iterable[tuple[Path, Path]],
+    presets_dir: Path,
+) -> None:
+    """Launch Adobe Media Encoder with encoding jobs.
+
+    Parameters
+    ----------
+    videos:
+        Iterable of ``(input_path, output_path)`` pairs.
+    presets_dir:
+        Directory containing ``.epr`` preset files exported from Adobe Media Encoder.
+        The first preset found is used for all videos.
+    """
+    presets = list(presets_dir.glob("*.epr"))
+    if not presets:
+        logger.warning("No video presets found in %s", presets_dir)
+        return
+
+    preset = presets[0]
+    for src, dst in videos:
+        try:
+            subprocess.Popen(  # noqa: S603
+                [AME_COMMAND, str(src), str(dst), str(preset)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            logger.info("Queued %s for Adobe Media Encoder", src.name)
+        except FileNotFoundError:
+            logger.error("Adobe Media Encoder executable not found")
+            break

--- a/tests/test_failed_file_logging.py
+++ b/tests/test_failed_file_logging.py
@@ -18,7 +18,7 @@ def test_failed_file_logging(tmp_path: Path) -> None:
     bad_file.write_text("not an image")
     output_dir = tmp_path / "out"
     compressor = ImageCompressor()
-    total, compressed, _, failed, _ = compressor.process_directory(input_dir, output_dir)
+    total, compressed, _, failed, _, _ = compressor.process_directory(input_dir, output_dir)
     assert total == 1
     assert compressed == 0
     assert len(failed) == 1

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -16,7 +16,7 @@ def test_process_directory_parallel(tmp_path: Path) -> None:
         Image.new("RGB", (10, 10)).save(input_dir / f"img{i}.jpg")
     output_dir = tmp_path / "out"
     compressor = ImageCompressor()
-    total, compressed, _, failed, _ = compressor.process_directory(input_dir, output_dir, num_workers=2)
+    total, compressed, _, failed, _, _ = compressor.process_directory(input_dir, output_dir, num_workers=2)
     assert total == 3
     assert compressed == 3
     assert failed == []

--- a/tests/test_video_collection.py
+++ b/tests/test_video_collection.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from service.image_compression import ImageCompressor
+
+
+def test_collects_video_files(tmp_path: Path) -> None:
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    video = input_dir / "clip.mp4"
+    video.write_bytes(b"data")
+    output_dir = tmp_path / "out"
+    unsupported_dir = tmp_path / "unsupported"
+    compressor = ImageCompressor(unsupported_dir=unsupported_dir)
+    total, compressed, _, failed, _, videos = compressor.process_directory(input_dir, output_dir, profiles=[])
+    assert total == 0
+    assert compressed == 0
+    assert failed == []
+    assert videos == [video]
+    assert not (unsupported_dir / "clip.mp4").exists()
+    assert not (output_dir / "clip.mp4").exists()


### PR DESCRIPTION
## Summary
- collect video files during image scan
- queue videos to Adobe Media Encoder using exported presets
- include presets directory and tests for video detection

## Testing
- `make lint.ruff`
- `make lint.mypy`
- `make test.pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68baab33c1b083329b5db4f11d2d6da9